### PR TITLE
feat(#54): 학생 과졔 페이지 및 선생 수업페이지 파싱 완료

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,12 +24,12 @@ function App() {
   useEffect(() => {
     const getJwtToken = async () => {
       try {
-        const response = await axios.post('http://10.129.57.64:8080/test', {
-          params: {
-            userId: 1,
-            username: '김한결',
-            role: 'STUDENT',
-          },
+        const response = await axios.post('http://10.129.57.64:8080/test?userId=1&username=김우성&role=STUDENT', {
+          // params: {
+          //   userId: 1,
+          //   username: '김한결',
+          //   role: 'STUDENT',
+          // },
         });
         const token = response.headers.authorization;
         console.log('JWT Token:', token);
@@ -44,6 +44,27 @@ function App() {
     } else {
       getJwtToken();
       localStorage.removeItem('accessToken');
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    const getJwtToken = async () => {
+      try {
+        const response = await axios.post('http://10.129.57.64:8080/test?userId=6&username=김기태&role=TEACHER', {
+        });
+        const token = response.headers.authorization;
+        console.log('JWT Token:', token);
+        setAccessToken(token);
+      } catch (error: any) {
+        console.error('JWT 발급 실패:', error.response?.data || error.message);
+      }
+    };
+
+    if (accessToken) {
+      localStorage.setItem('TaccessToken', accessToken);
+    } else {
+      getJwtToken();
+      localStorage.removeItem('TaccessToken');
     }
   }, [accessToken]);
 

--- a/src/features/ClassComponent/Assignment/Assignment.tsx
+++ b/src/features/ClassComponent/Assignment/Assignment.tsx
@@ -15,10 +15,10 @@ export function Assignment() {
     if (classId) {
       Customapi.get(`/api/assignments/${classId}`)
         .then(res => { 
-          console.log(res.data);
+          console.log("데이터",res.data);
           setAssignments(res.data);
         })
-        .catch(err => console.error(err));
+        .catch(err => console.error("오류코등",err));
     }
   }, [classId]);
 

--- a/src/features/ClassComponent/Assignment/AssignmentCard.tsx
+++ b/src/features/ClassComponent/Assignment/AssignmentCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Customapi from '@/shared/api/axios';
 import { IoCalendarClearOutline } from "react-icons/io5";
 import { LuClock4 } from "react-icons/lu";
 import { FaRegFile, FaXmark } from "react-icons/fa6";
@@ -30,6 +31,7 @@ export function AssignmentCard({ data }: AssignmentCardProps) {
     name: f.fileName,
     size: `${f.fileSize} MB`
   })) ?? [];
+  const assignmentId = data.assignmentId;
 
   // buttonType, hasFile 등은 내부 상태로 관리
   const [submitted, setSubmitted] = useState(false);
@@ -41,10 +43,15 @@ export function AssignmentCard({ data }: AssignmentCardProps) {
       alert("파일을 먼저 업로드 해주세요.");
       return;
     }
-    // assignmentId를 과제 식별자로 사용
-    const url = `/class/dummy/${data.assignmentId}/upload/`;
+    const assignmentId = data.assignmentId;
+    const url = `/api/assignments/submit/${assignmentId}`;
+    // 첫 번째 파일만 전송 (여러 파일 지원 필요시 반복문 사용)
+    const formData = new FormData();
+    formData.append("file", files[0] && files[0].name ? files[0].name : "");
     try {
-      await fetch(url);
+      await Customapi.post(url, formData, {
+        headers: { "Content-Type": "multipart/form-data" }
+      });
       setSubmitted(true);
       alert("과제가 제출되었습니다.");
       setShowUploadModal(false);
@@ -68,9 +75,8 @@ export function AssignmentCard({ data }: AssignmentCardProps) {
       const formData = new FormData();
       formData.append("file", f);
       try {
-        await fetch(`/class/dummy/${data.assignmentId}/upload`, {
-          method: 'POST',
-          body: formData,
+        await Customapi.post(`/api/assignments/submit/${assignmentId}`, formData, {
+          headers: { "Content-Type": "multipart/form-data" }
         });
         uploadedFiles.push({
           id: crypto.randomUUID(),
@@ -93,6 +99,9 @@ export function AssignmentCard({ data }: AssignmentCardProps) {
   const closeUploadModal = () => setShowUploadModal(false);
   const handleResubmitClick = () => {
     setSubmitted(false);
+    Customapi.delete(`/api/assignments/submit/${assignmentId}`)
+    .then(res => { console.log("제출취소") })
+    .catch(err => console.error(err));
   };
   const statusClass = submitted ? <StatusSubmitted>제출됨</StatusSubmitted> : <StatusNotSubmitted>미제출</StatusNotSubmitted>;
   const onFileInfoClick = (file: FileInfoType) => {

--- a/src/features/ClassComponent/Lesson/Lesson.tsx
+++ b/src/features/ClassComponent/Lesson/Lesson.tsx
@@ -7,6 +7,7 @@ import Customapi from "@/shared/api/axios";
 import LessonCard from "./LessonCard";
 import InfoBoard from "./InfoBoard/InfoBoard";
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 
 // 디렉토리 항목
 export interface DirectoryItem {
@@ -26,17 +27,39 @@ export interface DirectorySection {
 }
 
 export default function Lesson() {
-  // const [directories,setDirectories] = useState<DirectorySection>()
-  
-  // useEffect(() => {
-  //   Customapi
-  // })
+  const { classId } = useParams<{ classId: string }>();
+  const [directories,setDirectories] = useState<DirectorySection[]>([])
+
+  useEffect(() => {
+    if (classId) {
+      Customapi.get(`/api/class/${classId}/all`)
+        .then(res => { 
+          console.log(res.data);
+          const data = res.data;
+          // directoryList를 DirectorySection[] 형태로 변환
+          const sections = (data.directoryList ?? []).map((dir: any) => ({
+            classRoomId: String(data.classRoomId),
+            title: dir.directoryName,
+            items: (dir.documentList ?? []).map((doc: any) => ({
+              id: doc.documentId,
+              name: doc.title,
+              directoryOrder: dir.directoryOrder,
+              url: undefined, // 필요시 doc에 url 필드 추가
+              isRead: false,  // 필요시 읽음 여부 계산
+            })),
+            isExpanded: false,
+          }));
+          setDirectories(sections);
+        })
+        .catch(err => console.error(err));
+    }
+  }, [classId]);
 
   return (
     <LessonPageContainer>
       <ContentContainer>
         <LessonCardWrapper>
-          <LessonCard sections={Directories} />
+          <LessonCard sections={directories} classId={classId} />
         </LessonCardWrapper>
         <InfoBoardWrapper>
           <InfoBoard />

--- a/src/features/ClassComponent/Lesson/LessonCard.tsx
+++ b/src/features/ClassComponent/Lesson/LessonCard.tsx
@@ -11,13 +11,17 @@ import {
   LessonButton,
 } from "./styles";
 
-import { DirectorySection } from "@/shared/theme/LessonTheme";
+
+import { useNavigate } from 'react-router-dom';
+import { DirectorySection } from '@/features/ClassComponent/Lesson/Lesson';
 
 interface LessonCardProps {
   sections: DirectorySection[];
+  classId?: string;
 }
 
-const LessonCard: React.FC<LessonCardProps> = ({ sections }) => {
+const LessonCard: React.FC<LessonCardProps> = ({ sections, classId }) => {
+  const navigate = useNavigate();
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(
     () =>
       sections.reduce((acc, section) => {
@@ -47,17 +51,22 @@ const LessonCard: React.FC<LessonCardProps> = ({ sections }) => {
 
           {expandedSections[section.classRoomId] && (
             <SectionItems>
-              {section.items
+              {(section.items ?? [])
                 .sort((a, b) => a.directoryOrder - b.directoryOrder)
                 .map((item) => (
-                  <LessonItem key={item.id}>
+                  <LessonItem key={item.id}
+                    onClick={() => navigate(`/class/${section.classRoomId}`)}
+                  >
                     <StatusIndicator isRead={!!item.url}>
                       <CheckIcon />
                     </StatusIndicator>
                     {/* url 있으면 버튼(클릭 시 링크 이동), 없으면 그냥 텍스트 */}
                     {item.url ? (
                       <LessonButton
-                        onClick={() => window.open(item.url, "_blank")}
+                        onClick={e => {
+                          e.stopPropagation();
+                          window.open(item.url, "_blank");
+                        }}
                       >
                         {item.name}
                       </LessonButton>

--- a/src/features/ClassComponent/Teacher/Lesson/TLesson.tsx
+++ b/src/features/ClassComponent/Teacher/Lesson/TLesson.tsx
@@ -1,14 +1,43 @@
 import { Container, LessonCardWrapper, InfoBoardWrapper} from './styles';
-import { Directories } from '@/shared/theme/LessonTheme';
+import { useEffect, useState } from 'react';
+import TCustomapi from '@/shared/api/Taxios';
+import { useParams } from 'react-router-dom';
 
 import LessonCard from './TLessonCard';
 import InfoBoard from './TInfoBoard';
 
 export default function TLesson() {
+  const { classId } = useParams<{ classId: string }>();
+  const [directories, setDirectories] = useState([]);
+
+  useEffect(() => {
+    if (classId) {
+      TCustomapi.get(`/api/class/${classId}/all`)
+        .then(res => {
+          const data = res.data;
+          // directoryList를 DirectorySection[] 형태로 변환
+          const sections = (data.directoryList ?? []).map((dir: any) => ({
+            classRoomId: String(data.classRoomId),
+            title: dir.directoryName,
+            items: (dir.documentList ?? []).map((doc: any) => ({
+              id: doc.documentId,
+              name: doc.title,
+              directoryOrder: dir.directoryOrder,
+              url: undefined,
+              isRead: false,
+            })),
+            isExpanded: false,
+          }));
+          setDirectories(sections);
+        })
+        .catch(err => console.error(err));
+    }
+  }, [classId]);
+
   return (
     <Container>
       <LessonCardWrapper>
-        <LessonCard sections={Directories} />
+        <LessonCard sections={directories} classId={classId} />
       </LessonCardWrapper>
       <InfoBoardWrapper>
         <InfoBoard />

--- a/src/features/ClassComponent/Teacher/Lesson/TLessonCard.tsx
+++ b/src/features/ClassComponent/Teacher/Lesson/TLessonCard.tsx
@@ -10,38 +10,25 @@ import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import { FaCheck } from 'react-icons/fa6';
 import { FaPencilAlt } from 'react-icons/fa';
 import TAddContent from '../Lesson/AddContent/TAddContent';
+import { DirectorySection } from '@/features/ClassComponent/Lesson/Lesson';
 
-// DirectoryItem 타입
-export interface DirectoryItem {
-  id: number;
-  name: string;
-  directoryOrder: number;
-  url?: string;
-  isRead: boolean;
+interface LessonCardProps {
+  sections?: DirectorySection[];
+  classId?: string;
 }
 
-// DirectorySection 타입
-export interface DirectorySection {
-  classRoomId: string;
-  title: string;
-  items: DirectoryItem[];
-}
-
-// 내부 상태 타입: DirectorySection에 isExpanded 추가
-export interface LessonSectionType extends DirectorySection {
+interface LessonSectionType extends DirectorySection {
   isExpanded: boolean;
 }
 
-interface LessonCardProps {
-  sections: DirectorySection[];
-}
-
 const LessonCard: React.FC<LessonCardProps> = ({ sections: rawSections }) => {
+  // sections가 undefined/null일 때도 빈 배열로 처리
+  const safeSections = Array.isArray(rawSections) ? rawSections : [];
   // 초기 상태: 기존 sections에 isExpanded 필드만 추가
   const [sections, setSections] = useState<LessonSectionType[]>(
-    rawSections.map(section => ({
+    safeSections.map(section => ({
       ...section,
-      isExpanded: false,
+      isExpanded: section.isExpanded ?? false,
     }))
   );
 

--- a/src/features/ClassComponent/Teacher/MyClass/TClassCard.tsx
+++ b/src/features/ClassComponent/Teacher/MyClass/TClassCard.tsx
@@ -1,14 +1,20 @@
 import { useNavigate } from 'react-router-dom';
-import { type TPost } from '@/shared/theme/Teacher/MyClassTheme';
 import * as S from './styles';
 
-interface TClassCardProps extends TPost {}
+interface TClassCardProps {
+  classRoomId: string;
+  name: string;
+  sort: string;
+  target: string;
+  studentCount: number;
+  isActivation: number;
+}
 
 export function TClassCard({ classRoomId, name, sort, target, studentCount, isActivation }: TClassCardProps) {
   const navigate = useNavigate();
 
   return (
-    <S.CardContainer onClick={() => navigate(`/tclass/${classRoomId}`)}>
+    <S.CardContainer onClick={() => navigate(`/tclass/${classRoomId}/all`)}>
       <S.CardHeader>
         <S.Status active={isActivation === 1}>{isActivation === 1 ? '활성화' : '비활성화'}</S.Status>
       </S.CardHeader>

--- a/src/features/ClassComponent/Teacher/MyClass/TClassList.tsx
+++ b/src/features/ClassComponent/Teacher/MyClass/TClassList.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TCategoryTabs } from './TCategoryTabs';
 import { TClassCard } from './TClassCard';
-import { TPosts } from '@/shared/theme/Teacher/MyClassTheme';
+import TCustomapi from '@/shared/api/Taxios';
 import { CardGrid } from './styles';
 
 type TCategoryKey = '전체' | '활성화' | '비활성화';
@@ -25,13 +25,23 @@ const TcategoryMap: Record<TCategoryKey, number> = {
 export const TClassList: React.FC = () => {
   const [selectCategory, setSelectedCategory] = useState<TCategoryKey>('전체');
   const [searchQuery, setSearchQuery] = useState<string>('');
+  const [posts, setPosts] = useState<TPost[]>([]);
 
   const navigate = useNavigate();
 
+  useEffect(() => {
+    TCustomapi.get('/api/class')
+      .then(res => {
+        setPosts(res.data);
+        console.log(res.data);
+      })
+      .catch(err => console.error(err));
+  }, []);
+
   const filteredByCategory: TPost[] =
     selectCategory === '전체'
-      ? TPosts
-      : TPosts.filter((post: TPost) => post.isActivation === TcategoryMap[selectCategory]);
+      ? posts
+      : posts.filter((post: TPost) => post.isActivation === TcategoryMap[selectCategory]);
 
   const filteredPosts: TPost[] = filteredByCategory.filter((post: TPost) =>
     post.name.toLowerCase().includes(searchQuery.toLowerCase())

--- a/src/pages/ClassRoom/ClassRoom.tsx
+++ b/src/pages/ClassRoom/ClassRoom.tsx
@@ -1,14 +1,40 @@
 import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import Customapi from '@/shared/api/axios';
 import ClassRoomInfo from '@/shared/classInfo/ClassRoomInfo/ClassRoomInfo';
 import LessonGroup from '@/features/ClassComponent/ClassRoomInfo/LessonGroup/LessonGroup';
-import { Posts } from '@/shared/theme/ClassRoomInfoTheme';
 import NotFound from '../NotFound/NotFound';
 import * as S from './styles';
 
 export default function ClassRoom() {
   const { classId } = useParams<{ classId: string }>();
+  const [post, setPost] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
 
-  const post = Posts.find(p => p.classRoomId === classId);
+  useEffect(() => {
+    if (classId) {
+      Customapi.get(`/api/class/${classId}/all`)
+        .then(res => {
+          console.log('백엔드 응답:', res.data);
+          const data = res.data;
+          setPost({
+            classRoomId: String(data.classRoomId),
+            name: data.classRoomName,
+            description: data.description,
+            teacherName: Array.isArray(data.teacherNames) ? data.teacherNames.join(', ') : '',
+            maxProgress: data.directoryList?.length ?? 0,
+            progress: 0,
+          });
+        })
+        .catch((err) => {
+          console.error('API 에러:', err);
+          setPost(null);
+        })
+        .finally(() => setLoading(false));
+    }
+  }, [classId]);
+
+  if (loading) return null;
   if (!post) return <NotFound />;
 
   return (

--- a/src/pages/TClassRoom/TClassRoom.tsx
+++ b/src/pages/TClassRoom/TClassRoom.tsx
@@ -1,19 +1,41 @@
 import { useParams } from 'react-router-dom';
 import ClassRoomInfo from '@/shared/classInfo/ClassRoomInfo/ClassRoomInfo';
 import TLessonGroup from '@/features/ClassComponent/Teacher/ClassRoomInfo/TLessonGroup';
-import { Posts } from '@/shared/theme/ClassRoomInfoTheme';
 import TCheckStudent from '@/features/ClassComponent/Teacher/Assignment/TCheckStudent';
 import * as S from './styles';
 import NotFound from '../NotFound/NotFound';
+import { useEffect, useState } from 'react';
+import TCustomapi from '@/shared/api/Taxios';
 
 export default function TClassRoom() {
   const { classId, lessonId } = useParams<{ classId: string; lessonId?: string }>();
+  const [post, setPost] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
 
   if (lessonId) {
     return <TCheckStudent />;
   }
 
-  const post = Posts.find(p => p.classRoomId === classId);
+  useEffect(() => {
+    if (classId) {
+      TCustomapi.get(`/api/class/${classId}/all`)
+        .then(res => {
+          const data = res.data;
+          setPost({
+            classRoomId: String(data.classRoomId),
+            name: data.classRoomName,
+            description: data.description,
+            teacherName: Array.isArray(data.teacherNames) ? data.teacherNames.join(', ') : '',
+            maxProgress: data.directoryList?.length ?? 0,
+            progress: 0, // 필요시 계산
+          });
+        })
+        .catch(() => setPost(null))
+        .finally(() => setLoading(false));
+    }
+  }, [classId]);
+
+  if (loading) return null;
   if (!post) return <NotFound />;
 
   return (

--- a/src/shared/api/Taxios.ts
+++ b/src/shared/api/Taxios.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+
+const baseUrl = import.meta.env.VITE_API_BASE_URL;
+const TaccesToken = localStorage.getItem('TaccessToken');
+
+const TCustomapi = axios.create({
+  baseURL: baseUrl,
+  timeout: 10000,
+  headers: {
+    Authorization: `${TaccesToken}`
+  }
+});
+
+export default TCustomapi;


### PR DESCRIPTION
학생 과제페이지는 cors오류 떳음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 교사용 및 학생용 JWT 토큰을 각각 별도의 localStorage 키로 자동 발급 및 저장하는 기능이 추가되었습니다.
  * 교사용 Axios 기반 API 클라이언트가 추가되어, 인증 토큰을 자동으로 포함하여 요청합니다.

* **버그 수정**
  * 과제 데이터 및 오류 콘솔 출력 메시지가 한글로 개선되었습니다.

* **리팩터**
  * 과제 제출 및 파일 업로드, 과제 재제출 취소 로직이 통합된 API 클라이언트와 새로운 엔드포인트를 사용하도록 개선되었습니다.
  * 수업 자료와 강의 목록, 교사 클래스 목록이 정적 데이터에서 API를 통한 동적 데이터로 변경되었습니다.
  * 여러 컴포넌트에서 props 타입 구조가 명확하게 정의되고, 안전하게 데이터가 처리되도록 개선되었습니다.
  * 라우팅 및 네비게이션 동작이 일관성 있게 수정되었습니다.

* **기타**
  * 기존의 불필요한 주석 및 임시 코드가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->