### PR TITLE
feat(#64):디렉토리 클릭시 서브 디렉토리 애니메이션 추가

### DIFF
--- a/src/features/Common/Class/Lesson/index.tsx
+++ b/src/features/Common/Class/Lesson/index.tsx
@@ -104,20 +104,21 @@ const LessonComponent: React.FC<LessonProps> = ({ classRoomId }) => {
           {directories.map(dir => {
             const isExpanded = expandedIds.has(dir.id);
             return (
-              <s.DirectoryWrapper key={dir.id}>
+              <s.DirectoryWrapper key={dir.id}> 
                 <s.Item $isRead={dir.isRead} onClick={() => handleDirectoryClick(dir)}>
                   <s.Check>{dir.isRead && <FaCircleCheck />}</s.Check>
                   <s.Name>{dir.name}</s.Name>
                   <s.Icon>{isExpanded ? <IoIosArrowUp size={18} /> : <IoIosArrowDown size={18} />}</s.Icon>
                 </s.Item>
-
-                {isExpanded &&
-                  dir.subDirectories?.map(sub => (
+                {/* 서브디렉토리 */}
+                <s.SubDirectoryList $isExpanded={isExpanded}>
+                  {dir.subDirectories?.map(sub => (
                     <s.SubItem key={sub.id} $isRead={sub.isRead} onClick={() => handleDirectoryClick(sub, true)}>
                       <s.Check>{sub.isRead && <FaCircleCheck />}</s.Check>
                       <s.Name>{sub.name}</s.Name>
                     </s.SubItem>
                   ))}
+                </s.SubDirectoryList>
               </s.DirectoryWrapper>
             );
           })}

--- a/src/features/Common/Class/Lesson/styles.ts
+++ b/src/features/Common/Class/Lesson/styles.ts
@@ -92,3 +92,11 @@ export const ModalMeta = styled.p`
   margin: 0;
   padding: 0;
 `;
+
+export const SubDirectoryList = styled.div<{ $isExpanded: boolean }>`
+  overflow: auto;
+  max-height: ${({ $isExpanded }) => ($isExpanded ? '2000px' : '0')};
+  transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  flex-direction: column;
+`;


### PR DESCRIPTION
디렉토리 클릭시 서브 디렉토리에 애니메이션이 동작하도록 추가(수업에서)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 서브디렉토리 목록이 항상 렌더링되며, 확장 여부에 따라 부드럽게 펼쳐지거나 접히는 애니메이션 효과가 적용되었습니다.
  * 서브디렉토리 목록 상단에 "서브디렉토리" 주석이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->