### PR TITLE
feat(#83):MakeTask의 axios 연결

### DIFF
--- a/src/app/router/AppRoutes.tsx
+++ b/src/app/router/AppRoutes.tsx
@@ -29,7 +29,7 @@ export const AppRoutes = ({ role }: AppRoutesProps) => {
           <Route path="/class/:classRoomId" element={<STUClass />} />
           <Route path='/class/make' element={<TCHMakeClass />} />
           <Route path='/timeline' element={<AddTimeLine />} />
-          <Route path='/class/maketask' element={<TCHMakeTask />} />
+          <Route path='/class/:class/maketask' element={<TCHMakeTask />} />
           <Route path='/class/makescore' element={<TCHMakeScorecard />} />
           <Route path='/class/make/markdown' element={<TCHMarkDown />} />
         </>

--- a/src/entities/Class/AssignmentCard/index.tsx
+++ b/src/entities/Class/AssignmentCard/index.tsx
@@ -9,7 +9,7 @@ import Button from '@/entities/UI/Button';
 import { AssignmentCardProps, AssignmentFileType } from '@/shared/types/classroom';
 import { differenceInDays, parseISO } from 'date-fns';
 import { MdOutlineFileUpload } from "react-icons/md";
-import { submitAssignment, DeleteAssignment } from '../api';
+import { SubmitAssignment, DeleteAssignment } from '../api';
 
 
 interface UploadedFile { id: string; name: string; size: string; file?: File }  
@@ -86,7 +86,7 @@ export function AssignmentCard({ data }: AssignmentCardProps) {
     if (!fileToSubmit) return alert('파일 데이터가 없습니다.');
 
     try {
-      await submitAssignment(data.id, fileToSubmit);
+      await SubmitAssignment(data.id, fileToSubmit);
       setIsSubmitted(true);
       alert('과제 제출 완료');
       setShowUploadModal(false);

--- a/src/entities/Class/api.ts
+++ b/src/entities/Class/api.ts
@@ -2,7 +2,7 @@ import Customapi from "@/shared/config/api";
 
 // <--Class-->
 // 과제 제출 API
-export async function submitAssignment(assignmentId: string, file: File) {
+export async function SubmitAssignment(assignmentId: string, file: File) {
     try {
         const formData = new FormData();
         formData.append('file', file);

--- a/src/pages/Teacher/Main/index.tsx
+++ b/src/pages/Teacher/Main/index.tsx
@@ -11,7 +11,7 @@ import { TCHSchedule } from '@/features/Common/Main/Schedule/data';
 export default function Home() {
     return (
         <s.Container>
-            <MySchedule data={TCHSchedule}/>
+            {/* <MySchedule data={TCHSchedule}/> */}
             <TaskGuide />       {/* 수행평가 안내*/}
             <PendingTask />     {/* 미제출과제*/}
             <Notice />          {/* 공지/안내 */}

--- a/src/pages/Teacher/MakeTask/api.ts
+++ b/src/pages/Teacher/MakeTask/api.ts
@@ -1,0 +1,71 @@
+import Customapi from "@/shared/config/api";
+import { Integer } from "@stylexjs/stylex/lib/VarTypes";
+
+// <--MakeTask-->
+// MakeTask 만들기 api
+
+interface Attachment {
+    type: "file" | "link";
+    name: string;
+    url?: string;
+    file?: File;
+}
+
+interface Task {
+    classId: number;
+    title: string;
+    content: string;
+    start_date: string;
+    end_date: string;
+  }
+
+export async function SendMakeTask({classId, title, content, start_date, end_date}:Task) {
+    try {
+        const response = await Customapi.post(`/api/assignments`, {
+            class_id: classId,
+            title: title,
+            content: content,
+            start_date: start_date,
+            end_date: end_date
+        });
+        if (response.status !== 200) {
+            return response.status;
+        }
+
+        const assignmentId = response.data.assignment_id;
+        return assignmentId;
+    } catch (error) {
+        console.error('MakeTask 실패:', error);
+        throw error;
+    }
+}
+
+export async function attachFile(assignmentId: string, attachments: Attachment[]) {
+    try {
+        // 파일과 링크 분리
+        const files = attachments.filter(att => att.type === "file" && att.file);
+        const links = attachments.filter(att => att.type === "link" && att.url);
+        
+        // 파일 업로드
+        for (const fileAtt of files) { //여러개가 들어와도 처리
+            if (fileAtt.file) {
+                const formData = new FormData();
+                formData.append('file', fileAtt.file);
+                formData.append('name', fileAtt.name);
+                
+                await Customapi.post(`/api/assignments/${assignmentId}/files`, formData);
+            }
+        }
+        
+        if (links.length > 0) {
+            await Customapi.post(`/api/assignments/${assignmentId}/links`, {
+                links: links.map(link => ({ name: link.name, url: link.url })) // 여러개가 들어와도 처리
+            });
+        }
+        
+        return true;
+    } catch (error) {
+        console.error('첨부파일 업로드 실패:', error);
+        throw error;
+    }
+}

--- a/src/pages/Teacher/MakeTask/index.tsx
+++ b/src/pages/Teacher/MakeTask/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import * as S from "./styles";
 
 import { Modal } from "@/entities/UI/Modal";
@@ -7,6 +7,7 @@ import Button from "@/entities/UI/Button";
 import DateInput from "@/entities/UI/InputBox/DateInput";
 import InputBox from "@/entities/UI/InputBox/Input";
 import AttachmentBox from "@/entities/UI/Attachment";
+import { SendMakeTask, attachFile } from "./api";
 
 interface Attachment {
   type: "file" | "link";
@@ -16,6 +17,8 @@ interface Attachment {
 }
 
 const MakeTask = () => {
+  const { classId } = useParams<{ classId: string | '' }>();
+
   const navigate = useNavigate();
   const today = new Date().toISOString().split("T")[0];
 
@@ -61,6 +64,25 @@ const MakeTask = () => {
     setLinkPlatform(null);
     setIsLinkModalOpen(false);
   };
+
+  const MakeTask = async () => {
+    if (classId) {
+      const taskData = {
+        classId: Number(classId),
+        title: subject,
+        content: description,
+        start_date: startDate,
+        end_date: dueDate
+      };
+      try {
+        const assignmentId = await SendMakeTask(taskData);
+        await attachFile(assignmentId, attachments);
+        console.log("과제 생성완료");
+      } catch(error) {
+        console.error('과제 생성 실패:',error)
+      }
+    }
+  }
 
   return (
     <S.Container>
@@ -112,7 +134,7 @@ const MakeTask = () => {
       <Button
         text="완료"
         disabled={!isFormValid}
-        onClick={() => alert("제출 완료")}
+        onClick={() => MakeTask()}
       />
 
       {/* 파일 업로드 모달 */}


### PR DESCRIPTION
MakeTask의 axios 연결 및 file과 link구분 및 따로 api 보내도록 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 교사용 과제 생성이 클래스별 화면으로 분리되어, 특정 클래스 컨텍스트에서 과제를 생성할 수 있습니다.
  * 과제 생성 시 파일과 링크 첨부를 지원하여 자료를 함께 업로드할 수 있습니다.
* 변경 사항
  * 과제 생성 페이지 이동 경로가 클래스 식별자를 포함하도록 업데이트되었습니다. 이에 따라 이전의 직접 접근 경로는 더 이상 사용되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->