### PR TITLE
feat(#142): 엑세스 토큰 및 유저 정보 테스트용으로 제작 및 cors에러 해결

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,8 +22,16 @@ export default function App() {
 }
 
 function AuthWrapper() {
-  const { accessToken, user, setAuthInfo, removeAuthInfo } = useAuth();
-
+  const {  setAuthInfo, removeAuthInfo } = useAuth();
+  const accessToken = "eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6ImFjY2VzcyIsInVzZXJJZCI6MSwidXNlcm5hbWUiOiJhZG1pbiIsInJvbGUiOiJURUFDSEVSIiwiaWF0IjoxNzU2NjU2MDY1LCJleHAiOjE3NTcwMTYwNjV9.1tiEURPjqgtl3JLnrOzV321h8tP96MWMLCdHEg7An7o";
+  localStorage.setItem('accessToken', accessToken);
+  
+  const user = {
+    userId: '1',
+    username: 'admin',
+    role: 'TEACHER',
+  };
+  
   let role = user?.role || null;
   if (role === 'STUDENT') role = 'STU';
   else if (role === 'TEACHER') role = 'TCH';

--- a/src/app/hooks/useAccessToken.ts
+++ b/src/app/hooks/useAccessToken.ts
@@ -11,11 +11,19 @@ export const useAuth = () => {
 
   const [user, setUser] = useRecoilState(userState);
 
+  const TEST_TOKEN = 'eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6ImFjY2VzcyIsInVzZXJJZCI6MSwidXNlcm5hbWUiOiJhZG1pbiIsInJvbGUiOiJURUFDSEVSIiwiaWF0IjoxNzU2NjU2MDY1LCJleHAiOjE3NTcwMTYwNjV9.1tiEURPjqgtl3JLnrOzV321h8tP96MWMLCdHEg7An7o';
+  const TEST_USER: User = {
+    userId: '1',
+    username: 'admin',
+    role: 'TEACHER',
+  };
+
   // 로그인시 사용자 정보 및 토큰 세팅
-  const setAuthInfo = (token: string, userInfo: User) => {
-    localStorage.setItem('accessToken', token);
-    setAccessToken(token);
-    setUser(userInfo);
+  // const setAuthInfo = (token: string, userInfo: User) => {
+    const setAuthInfo = () => {
+    localStorage.setItem('accessToken', TEST_TOKEN);
+    setAccessToken(TEST_TOKEN);
+    setUser(TEST_USER);
   };
 
   // 로그아웃

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,8 +17,9 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://paletto.site:8080',
         changeOrigin: true,
+        secure: false,
       },
     },
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 앱 실행 시 기본 사용자로 자동 로그인되어 즉시 이용할 수 있습니다.
  - 사용자 역할 표기가 약어(STU/TCH)로 통일되었습니다.
- 기타(환경)
  - 개발 환경의 API 프록시 대상 서버를 paletto.site:8080으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->