### PR TITLE
Refactor(#151): 디렉토리 type error해결

### DIFF
--- a/src/features/Common/Class/Lesson/index.tsx
+++ b/src/features/Common/Class/Lesson/index.tsx
@@ -27,28 +27,28 @@ const LessonComponent: React.FC<LessonProps> = ({ classRoomId }) => {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
   // 데이터 불러오기
-useEffect(() => {
-  const fetchData = async () => {
-    try {
-      const classInfo = await getLessonDirectories(classRoomId);
-      const dirs: Directory[] = classInfo.directoryList.map((dir:any) => ({
-        id: dir.directoryId.toString(),
-        name: dir.directoryName,
-        isRead: false,
-        subDirectories: [], // 필요시 documentList로 변환 가능
-      }));
-      setDirectories(dirs);
-      setNews(await getLessonNews(classRoomId));
-      setQuestions(await getLessonQuestions(classRoomId));
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const classInfo = await getLessonDirectories(classRoomId);
+        const dirs: Directory[] = classInfo.directoryList.map((dir) => ({
+          id: dir.directoryId.toString(),
+          name: dir.directoryName,
+          isRead: false,
+          directoryList: [], // 필요시 documentList로 변환 가능
+        }));
+        setDirectories(dirs);
+        setNews(await getLessonNews(classRoomId));
+        setQuestions(await getLessonQuestions(classRoomId));
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  if (classRoomId) fetchData();
-}, [classRoomId]);
+    if (classRoomId) fetchData();
+  }, [classRoomId]);
 
   const toggleDirectory = (id: string) => {
     setExpandedIds(prev => {
@@ -62,12 +62,12 @@ useEffect(() => {
     if (isSubDirectory) {
       setDirectories(prev =>
         prev.map(d => {
-          if (d.subDirectories) {
-            const newSubDirs = d.subDirectories.map(sd =>
+          if (d.directoryList) {
+            const newSubDirs = d.directoryList.map(sd =>
               sd.id === dir.id ? { ...sd, isRead: true } : sd
             );
             const allSubRead = newSubDirs.every(sd => sd.isRead);
-            return { ...d, subDirectories: newSubDirs, isRead: allSubRead };
+            return { ...d, directoryList: newSubDirs, isRead: allSubRead };
           }
           return d;
         })
@@ -93,7 +93,7 @@ useEffect(() => {
                   <s.Icon>{isExpanded ? <IoIosArrowUp size={18} /> : <IoIosArrowDown size={18} />}</s.Icon>
                 </s.Item>
                 <s.SubDirectoryList $isExpanded={isExpanded}>
-                  {dir.subDirectories?.map(sub => (
+                  {dir.directoryList?.map(sub => (
                     <s.SubItem
                       key={sub.id}
                       $isRead={sub.isRead}

--- a/src/features/Common/Class/api.ts
+++ b/src/features/Common/Class/api.ts
@@ -3,6 +3,14 @@ import { Assignment } from '@/shared/types/Class/Assignment/assignmentAttachment
 import { Exam } from '@/shared/types/Class/Exam';
 import { NewsItem, QuestionItem, Directory } from '@/shared/types/Class/Lesson';
 
+// API 응답 타입 정의
+interface DirectoryApiResponse {
+  directoryList: Array<{
+    directoryId: number;
+    directoryName: string;
+  }>;
+}
+
 // 과제 목록 조회
 export const AssignmentsApi = async (classId: string): Promise<Assignment[]> => {
   const response = await Customapi.get(`/api/assignments/${classId}/all`);
@@ -26,11 +34,11 @@ export const ExamApi = async (examNumber: string): Promise<Exam[]> => {
 };
 
 // 수업 디렉토리 조회(없음)
-export const getLessonDirectories = async (classRoomId: string): Promise<Directory[]> => {
+export const getLessonDirectories = async (classRoomId: string): Promise<DirectoryApiResponse> => {
   const res = await Customapi.get(`/api/class/${classRoomId}/all`);
   if (res.status !== 200) {
     console.error(`수업 디렉토리 조회 실패: ${res.status}`);
-    return [];
+    return { directoryList: [] };
   }
   console.log(res.data);
   return res.data;

--- a/src/pages/Teacher/Make/MakeClass/index.tsx
+++ b/src/pages/Teacher/Make/MakeClass/index.tsx
@@ -31,7 +31,7 @@ export default function MakeClass() {
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async () => {
-    const dataToSend = { ...basicInfo, ...classroomSetup };
+    const dataToSend = { ...basicInfo, isActivated: classroomSetup.isActivated };
     setLoading(true);
 
     try {
@@ -42,7 +42,7 @@ export default function MakeClass() {
       }
 
       navigate('/class'); // 성공 시 MyClass 페이지로 이동
-    } catch (err: any) {
+    } catch (err) {
       console.error('학습실 생성 실패:', err);
     } finally {
       setLoading(false);

--- a/src/shared/types/Class/Lesson.ts
+++ b/src/shared/types/Class/Lesson.ts
@@ -2,7 +2,7 @@ export interface Directory {
   id: string;
   name: string;
   isRead: boolean;
-  subDirectories?: Directory[];
+  directoryList?: Directory[];
 }
 
 export interface NewsItem {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 디렉터리 불러오기 실패 시 빈 목록으로 안전 처리하여 화면 오류를 방지했습니다.
- Refactor
  - 하위 폴더 데이터 구조를 정리해 디렉터리 목록 표시의 일관성을 개선했습니다. 기존 탐색 흐름은 그대로 유지됩니다.
- Chores
  - 수업 생성 시 서버로 전송되는 데이터에서 채팅 사용 여부 설정을 제외했습니다. 기존 생성/이동 흐름에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->