### PR TITLE
Feat#197

### DIFF
--- a/src/entities/Class/ClassInfo/styles.ts
+++ b/src/entities/Class/ClassInfo/styles.ts
@@ -19,11 +19,7 @@ export const Container = styled.div`
 
   @media (max-width: 768px) {
     padding: 2rem 1rem;
-  }
-
-  @media (max-width: 480px) {
-    padding: 1rem 0.5rem;
-  }
+}
 `;
 
 export const LeftSection = styled.div`

--- a/src/entities/Main/DdayCard/styles.ts
+++ b/src/entities/Main/DdayCard/styles.ts
@@ -28,7 +28,7 @@ export const Card = styled.a<{ isUrgent: boolean }>`
   }
 
   @media (max-width: 768px) {
-    max-width: 100%;  // 모바일에서는 부모 너비 100%
+    max-width: 100%;
     padding: 1rem;
   }
 `;

--- a/src/entities/Main/NoticeCard/styles.ts
+++ b/src/entities/Main/NoticeCard/styles.ts
@@ -64,11 +64,11 @@ export const Row = styled.div`
   gap: 32px;
   width: 100%;
 
-  @media (max-width: 1024px) {
+  @media (max-width: 1200px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (max-width: 640px) {
+  @media (max-width: 768px) {
     grid-template-columns: 1fr;
   }
 `;

--- a/src/entities/Make/Lesson/directory/styles.ts
+++ b/src/entities/Make/Lesson/directory/styles.ts
@@ -1,5 +1,4 @@
 /** @jsxImportSource @emotion/react */
-import { fonts } from "@/shared/theme/font.styles";
 import { theme } from "@/shared/theme/theme.styles";
 import styled from "@emotion/styled";
 
@@ -13,6 +12,10 @@ export const SelectBox = styled.div`
   cursor: pointer;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
+
+  @media (max-width: 768px) {
+    padding: 0.5rem;
+  }
 `;
 
 export const AddButton = styled.div`
@@ -22,6 +25,10 @@ export const AddButton = styled.div`
   border: 1px solid #ddd;
   border-radius: 8px;
   margin-bottom: 0.5rem;
+
+  @media (max-width: 768px) {
+    padding: 0.5rem;
+  }
 `;
 
 export const Input = styled.input`
@@ -43,6 +50,10 @@ export const DirectoryContainer = styled.div`
   gap: 0.5rem;
   margin-bottom: 0.5rem;
   position: relative;
+
+  @media (max-width: 768px) {
+    padding: 0.5rem;
+  }
 `;
 
 export const DirectoryInput = styled.input`

--- a/src/entities/Setting/Link/styles.ts
+++ b/src/entities/Setting/Link/styles.ts
@@ -9,6 +9,10 @@ export const LinkItemWrapper = styled.div`
   padding: 12px 0;
   border-bottom: 1px solid #f1f3f5;
   cursor: pointer;
+
+  @ media (max-width: 768px) {
+    padding: 8px 0;
+  }
 `;
 
 export const TextGroup = styled.div`

--- a/src/entities/Setting/Link/styles.ts
+++ b/src/entities/Setting/Link/styles.ts
@@ -10,7 +10,7 @@ export const LinkItemWrapper = styled.div`
   border-bottom: 1px solid #f1f3f5;
   cursor: pointer;
 
-  @ media (max-width: 768px) {
+  @media (max-width: 768px) {
     padding: 8px 0;
   }
 `;

--- a/src/entities/UI/AddModal/styles.ts
+++ b/src/entities/UI/AddModal/styles.ts
@@ -14,11 +14,6 @@ export const ModalWrapper = styled.div`
     padding: 16px;
     max-width: 90%;
   }
-
-  @media (max-width: 480px) {
-    padding: 12px;
-    border-radius: 8px;
-  }
 `;
 
 export const Title = styled.h2`
@@ -27,7 +22,7 @@ export const Title = styled.h2`
   font-weight: 600;
   color: ${theme.colors.black};
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     ${fonts.P2};
   }
 `;

--- a/src/entities/UI/Attachment/styles.ts
+++ b/src/entities/UI/Attachment/styles.ts
@@ -11,7 +11,7 @@ export const Title = styled.div`
   margin-bottom: 0.5rem;
   ${fonts.P3};
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     ${fonts.P2};
   }
 `;
@@ -41,7 +41,7 @@ export const Button = styled.button`
     background: ${theme.colors.gray[100]};
   }
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     flex: 1 1 40%;
   }
 `;
@@ -68,7 +68,7 @@ export const Item = styled.div`
   position: relative;
   word-break: break-word; // 긴 파일명 처리
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     ${fonts.P2};
     padding: 6px 10px;
   }

--- a/src/entities/UI/Modal/styles.ts
+++ b/src/entities/UI/Modal/styles.ts
@@ -28,7 +28,7 @@ export const ModalWrapper = styled.div.withConfig({
       ? '0 0 15px 5px red'
       : '0 0 10px rgba(0,0,0,0.1)'};
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     width: 90%;
   }
 `;

--- a/src/entities/UI/TabSelect/styles.ts
+++ b/src/entities/UI/TabSelect/styles.ts
@@ -30,7 +30,7 @@ export const TabButton = styled.button<TabButtonProps>`
   font-weight: ${({ active }) => (active ? 600 : "normal")};
   color: ${({ active }) => (active ? theme.colors.black : theme.colors.gray[600])};
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     padding: 0.4rem 0.8rem;
     ${fonts.P2};
   }

--- a/src/entities/UI/ToggleSwitch/styles.ts
+++ b/src/entities/UI/ToggleSwitch/styles.ts
@@ -7,7 +7,7 @@ export const Wrapper = styled.div`
   align-items: center;
   gap: 8px;
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     gap: 6px;
   }
 `;
@@ -23,7 +23,7 @@ export const Switch = styled.label`
   width: 64px;
   height: 32px;
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     width: 48px;
     height: 24px;
   }
@@ -45,7 +45,7 @@ export const Checkbox = styled.input<{ checked?: boolean }>`
   &:checked + span::before {
     transform: translateX(40px) translateY(-50%);
 
-    @media (max-width: 480px) {
+    @media (max-width: 768px) {
     transform: translateX(30px) translateY(-50%);
     }
   }
@@ -75,14 +75,14 @@ export const Slider = styled.span`
     transition: 0.3s;
     border-radius: 50%;
 
-    @media (max-width: 480px) {
+    @media (max-width: 768px) {
       height: 14px;
       width: 14px;
       left: 2px;
     }
   }
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     padding: 0 2px;
     border-radius: 20px;
   }

--- a/src/features/Common/Class/Assignment/styles.ts
+++ b/src/features/Common/Class/Assignment/styles.ts
@@ -58,7 +58,7 @@ export const Status = styled.span<StatusProps>`
   border-radius: 12px;
   user-select: none;
 
-  @media (max-width: 600px) {
+  @media (max-width: 768px) {
     padding: 1px 6px;
   };
 `;
@@ -86,7 +86,7 @@ export const TimeInfo = styled.div`
 export const Footer = styled.div`
   padding: 8px 16px 16px 16px;
 
-  @media (max-width: 600px) {
+  @media (max-width: 768px) {
     padding: 8px 12px 12px 12px;
   }
 `;

--- a/src/features/Common/Main/Schedule/styles.ts
+++ b/src/features/Common/Main/Schedule/styles.ts
@@ -27,10 +27,6 @@ export const Title = styled.h1`
   @media (max-width: 768px) {
     ${fonts.P4};
   }
-
-  @media (max-width: 480px) {
-    ${fonts.P3};
-  }
 `;
 
 export const Explain = styled.p`
@@ -39,7 +35,7 @@ export const Explain = styled.p`
   padding: 0;
   margin: 0;
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     ${fonts.P1};
   }
 `;
@@ -57,11 +53,6 @@ export const Wrapper = styled.div`
     flex-direction: column;
     gap: 1.5rem;
     padding: 1.5rem;
-  }
-
-  @media (max-width: 480px) {
-    padding: 1rem;
-    gap: 1rem;
   }
 `;
 

--- a/src/features/Common/Main/TaskGuide/styles.ts
+++ b/src/features/Common/Main/TaskGuide/styles.ts
@@ -14,10 +14,6 @@ export const Container = styled.div`
   @media (max-width: 768px) {
     padding: 20px 2rem;
   }
-
-  @media (max-width: 480px) {
-    padding: 15px 1rem;
-  }
 `;
 
 export const CardContainer = styled.div`
@@ -37,10 +33,6 @@ export const CardContainer = styled.div`
 
   @media (max-width: 768px) {
     grid-template-columns: repeat(3, 1fr);
-    max-height: 300px;
-  }
-  @media (max-width: 600px) {
-    grid-template-columns: repeat(2, 1fr);
     max-height: 300px;
   }
 `;

--- a/src/features/Teacher/Assignment/styles.ts
+++ b/src/features/Teacher/Assignment/styles.ts
@@ -27,7 +27,7 @@ export const Grid = styled.div`
     grid-template-columns: repeat(3, 1fr);
   }
 
-  @media (max-width: 7681px) {
+  @media (max-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
   }
 `;

--- a/src/features/Teacher/Assignment/styles.ts
+++ b/src/features/Teacher/Assignment/styles.ts
@@ -16,10 +16,6 @@ export const Container = styled.div`
   @media (max-width: 768px) {
     padding: 1.5rem 2rem;
   }
-
-  @media (max-width: 480px) {
-    padding: 1rem;
-  }
 `;
 
 export const Grid = styled.div`
@@ -31,12 +27,8 @@ export const Grid = styled.div`
     grid-template-columns: repeat(3, 1fr);
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 7681px) {
     grid-template-columns: repeat(2, 1fr);
-  }
-
-  @media (max-width: 600px) {
-    grid-template-columns: 1fr;
   }
 `;
 
@@ -138,7 +130,7 @@ export const AddButton = styled.div`
   right: 2rem;
   z-index: 10;
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     bottom: 1.5rem;
     right: 1.5rem;
   }

--- a/src/pages/NotFound/styles.ts
+++ b/src/pages/NotFound/styles.ts
@@ -29,11 +29,6 @@ export const Image = styled.img`
     max-width: 180px;
     margin-bottom: 1rem;
   }
-
-  @media (max-width: 480px) {
-    max-width: 140px;
-    margin-bottom: 0.8rem;
-  }
 `;
 
 export const Message = styled.p`
@@ -48,11 +43,6 @@ export const Message = styled.p`
   @media (max-width: 768px) {
     ${fonts.P3}
     margin-bottom: 0.8rem;
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P2}
-    margin-bottom: 0.6rem;
   }
 `;
 
@@ -72,9 +62,5 @@ export const GoToMain = styled.div`
 
   @media (max-width: 768px) {
     ${fonts.P3}
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P2}
   }
 `;

--- a/src/pages/Student/MyClass/styles.ts
+++ b/src/pages/Student/MyClass/styles.ts
@@ -13,10 +13,6 @@ export const Container = styled.div`
   @media (max-width: 768px) {
     padding: 1.5rem 2rem;
   }
-
-  @media (max-width: 480px) {
-    padding: 1rem 1rem;
-  }
 `;
 
 export const TitleFont = styled.h1`
@@ -31,11 +27,6 @@ export const TitleFont = styled.h1`
   @media (max-width: 768px) {
     ${fonts.P3}
     margin-bottom: 16px;
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P2}
-    margin-bottom: 12px;
   }
 `;
 
@@ -56,12 +47,6 @@ export const AddButton = styled.button`
   @media (max-width: 768px) {
     width: 140px;
     height: 32px;
-    ${fonts.P3};
-  }
-
-  @media (max-width: 480px) {
-    width: 120px;
-    height: 30px;
     ${fonts.P3};
   }
 `;
@@ -89,10 +74,6 @@ export const ModalInput = styled.input`
   @media (max-width: 768px) {
     padding: 0.5rem 0.8rem;
   }
-
-  @media (max-width: 480px) {
-    padding: 0.4rem 0.6rem;
-  }
 `;
 
 export const EmptyMessage = styled.p`
@@ -106,10 +87,6 @@ export const Grid = styled.div`
 
   @media (max-width: 768px) {
     gap: 12px;
-  }
-
-  @media (max-width: 480px) {
-    gap: 8px;
   }
 `;
 
@@ -148,10 +125,6 @@ export const CardTitle = styled.h2`
   @media (max-width: 768px) {
     ${fonts.P3};
   }
-
-  @media (max-width: 480px) {
-    ${fonts.P2};
-  }
 `;
 
 export const CardDescription = styled.p`
@@ -160,10 +133,6 @@ export const CardDescription = styled.p`
 
   @media (max-width: 768px) {
     ${fonts.P3};
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P2};
   }
 `;
 
@@ -183,9 +152,6 @@ export const InfoContent = styled.p`
     ${fonts.P3};
   }
 
-  @media (max-width: 480px) {
-    ${fonts.P2};
-  }
 `;
 
 export const ErrorMessage = styled.p`
@@ -194,10 +160,6 @@ export const ErrorMessage = styled.p`
 
   @media (max-width: 768px) {
     margin-bottom: 12px;
-  }
-
-  @media (max-width: 480px) {
-    margin-bottom: 8px;
   }
 `;
 
@@ -213,7 +175,4 @@ export const AddModalInput = styled.input`
     padding: 0.5rem 0.8rem;
   }
 
-  @media (max-width: 480px) {
-    padding: 0.4rem 0.6rem;
-  }
 `;

--- a/src/pages/Teacher/AddTimeLine/styles.ts
+++ b/src/pages/Teacher/AddTimeLine/styles.ts
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled';
-import { theme } from '@/shared/theme/theme.styles';
-import { fonts } from '@/shared/theme/font.styles';
+import styled from "@emotion/styled";
+import { theme } from "@/shared/theme/theme.styles";
+import { fonts } from "@/shared/theme/font.styles";
 
 export const Container = styled.div`
   padding: 2rem 8rem;
@@ -12,10 +12,6 @@ export const Container = styled.div`
 
   @media (max-width: 768px) {
     padding: 1.5rem 2rem;
-  }
-
-  @media (max-width: 480px) {
-    padding: 1rem 1rem;
   }
 `;
 
@@ -30,10 +26,6 @@ export const Title = styled.h1`
 
   @media (max-width: 768px) {
     ${fonts.P3};
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P2};
   }
 `;
 
@@ -60,10 +52,6 @@ export const InfoIcon = styled.span`
   @media (max-width: 768px) {
     ${fonts.P3};
   }
-
-  @media (max-width: 480px) {
-    ${fonts.P2};
-  }
 `;
 
 export const InfoText = styled.p`
@@ -73,10 +61,6 @@ export const InfoText = styled.p`
 
   @media (max-width: 768px) {
     ${fonts.P2};
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P1};
   }
 `;
 
@@ -114,10 +98,6 @@ export const TeacherLabel = styled.label`
   @media (max-width: 768px) {
     ${fonts.P3};
   }
-
-  @media (max-width: 480px) {
-    ${fonts.P2};
-  }
 `;
 
 export const TeacherInputField = styled.input`
@@ -137,11 +117,6 @@ export const TeacherInputField = styled.input`
     padding: 10px 14px;
     ${fonts.P2};
   }
-
-  @media (max-width: 480px) {
-    padding: 8px 12px;
-    ${fonts.P3};
-  }
 `;
 
 export const ButtonGroup = styled.div`
@@ -151,10 +126,6 @@ export const ButtonGroup = styled.div`
 
   @media (max-width: 768px) {
     gap: 10px;
-  }
-
-  @media (max-width: 480px) {
-    gap: 8px;
   }
 `;
 
@@ -179,11 +150,6 @@ export const PDFB = styled.button`
     padding: 10px 14px;
     ${fonts.P2};
   }
-
-  @media (max-width: 480px) {
-    padding: 8px 12px;
-    ${fonts.P3};
-  }
 `;
 
 export const GoogleSheetB = styled.button`
@@ -202,11 +168,6 @@ export const GoogleSheetB = styled.button`
   @media (max-width: 768px) {
     padding: 10px 14px;
     ${fonts.P2};
-  }
-
-  @media (max-width: 480px) {
-    padding: 8px 12px;
-    ${fonts.P3};
   }
 `;
 

--- a/src/pages/Teacher/Make/MakeScorecard/styles.ts
+++ b/src/pages/Teacher/Make/MakeScorecard/styles.ts
@@ -17,10 +17,6 @@ export const Container = styled.div`
   @media (max-width: 768px) {
     padding: 1.5rem 2rem;
   }
-
-  @media (max-width: 480px) {
-    padding: 1rem 1rem;
-  }
 `;
 
 export const Title = styled.div`
@@ -91,10 +87,6 @@ export const GridRow = styled.div<{ columnCount?: number }>`
   @media (max-width: 768px) {
     gap: 6px;
   }
-
-  @media (max-width: 480px) {
-    gap: 4px;
-  }
 `;
 
 export const HeaderField = styled.input`
@@ -112,10 +104,6 @@ export const HeaderField = styled.input`
   @media (max-width: 768px) {
     ${fonts.P2};
   }
-
-  @media (max-width: 480px) {
-    ${fonts.P3};
-  }
 `;
 
 export const RemoveButton = styled.button`
@@ -132,7 +120,7 @@ export const RemoveButton = styled.button`
     color: ${theme.colors.blue[500]};
   }
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     top: 2px;
     right: 2px;
   }
@@ -155,11 +143,6 @@ export const CellBox = styled.div`
     min-height: 60px;
     padding: 6px;
   }
-
-  @media (max-width: 480px) {
-    min-height: 50px;
-    padding: 4px;
-  }
 `;
 
 export const SpacerCell = styled.div`
@@ -179,10 +162,6 @@ export const HeaderBox = styled.div`
   @media (max-width: 768px) {
     padding: 8px;
   }
-
-  @media (max-width: 480px) {
-    padding: 6px;
-  }
 `;
 
 export const TextArea = styled.textarea`
@@ -200,10 +179,6 @@ export const TextArea = styled.textarea`
   @media (max-width: 768px) {
     min-height: 60px;
   }
-
-  @media (max-width: 480px) {
-    min-height: 50px;
-  }
 `;
 
 export const TextBlock = styled.div`
@@ -213,10 +188,6 @@ export const TextBlock = styled.div`
 
   @media (max-width: 768px) {
     ${fonts.P3};
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P4};
   }
 `;
 
@@ -228,10 +199,6 @@ export const RowAddWrapper = styled.div`
 
   @media (max-width: 768px) {
     margin-top: 12px;
-  }
-
-  @media (max-width: 480px) {
-    margin-top: 8px;
   }
 `;
 
@@ -255,11 +222,6 @@ export const AddRowButton = styled.button`
     height: 36px;
     padding: 10px 0;
   }
-
-  @media (max-width: 480px) {
-    height: 32px;
-    padding: 8px 0;
-  }
 `;
 
 export const AddColumnButton = styled.button`
@@ -282,10 +244,6 @@ export const AddColumnButton = styled.button`
 
   @media (max-width: 768px) {
     ${fonts.P3};
-  }
-
-  @media (max-width: 480px) {
-    ${fonts.P2};
   }
 `;
 

--- a/src/pages/Teacher/Make/MakeTask/styles.ts
+++ b/src/pages/Teacher/Make/MakeTask/styles.ts
@@ -16,10 +16,6 @@ export const Container = styled.div`
   @media (max-width: 768px) {
     padding: 2rem 2rem;
   }
-
-  @media (max-width: 480px) {
-    padding: 1rem 1rem;
-  }
 `;
 
 export const HeaderRow = styled.div`
@@ -40,7 +36,7 @@ export const FileItem = styled.div`
   padding: 0.5rem;
   border-radius: 5px;
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     padding: 0.4rem;
     ${fonts.P2}
   }
@@ -53,10 +49,6 @@ export const Title = styled.div`
   @media (max-width: 768px) {
     ${fonts.P4};
   }
-
-  @media (max-width: 480px) {
-    ${fonts.P3};
-  }
 `;
 
 export const Label = styled.label`
@@ -66,10 +58,6 @@ export const Label = styled.label`
 
   @media (max-width: 768px) {
     margin-bottom: 6px;
-  }
-
-  @media (max-width: 480px) {
-    margin-bottom: 4px;
     ${fonts.P2};
   }
 `;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 스타일
  - 다수 컴포넌트에서 480px 전용 규칙 제거 및 768px 기준으로 반응형 범위 확대하여 소형·중형 뷰포트에서 패딩·폰트·간격 일관성 향상.
  - NoticeCard 그리드 전환 시점 조정: 2열(≤1200px), 1열(≤768px).
  - 모달·추가 모달 및 첨부·탭·토글스위치 등에서 90% 너비·타이포/컴팩트 스타일 적용 범위 확대.
  - 일부 그리드/버튼/레이아웃의 브레이크포인트 재정렬(≤768px으로 통합).

- 잡무
  - 사용하지 않는 import 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->