### PR TITLE
Feat(#201): 설정 페이지 연결

### DIFF
--- a/src/widgets/UserMenu/index.tsx
+++ b/src/widgets/UserMenu/index.tsx
@@ -38,7 +38,7 @@ export default function Dropdown({ role, studentNumber, name, myImage }: Dropdow
             <s.ProfileStudentNumber>{studentNumber}</s.ProfileStudentNumber>
           </s.ProfileInfoBox>
 
-          <s.DropdownItem href="#setting"><AiFillSetting />&nbsp;설정</s.DropdownItem>
+          <s.DropdownItem href="/setting"><AiFillSetting />&nbsp;설정</s.DropdownItem>
           <s.DropdownItem href="#Q&A"><AiFillQuestionCircle />&nbsp;문의하기</s.DropdownItem>
           <s.DropdownItem href="#logout"><MdOutlineLogout />&nbsp;로그아웃</s.DropdownItem>
         </s.DropdownMenu>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 사용자 메뉴의 ‘설정’ 항목이 해시 이동(#setting)에서 라우터 경로(/setting)로 변경되었습니다. 이제 클릭 시 설정 페이지로 정상 이동하며, 브라우저 뒤로가기/앞으로가기와 새로고침 시 상태가 올바르게 유지됩니다.
  - 깊은 링크가 지원되어 설정 페이지를 직접 북마크하거나 URL로 공유할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->