### PR TITLE
Design(#203): ClassInfo css 수정(사이즈만 줄어들게)

### DIFF
--- a/src/entities/Class/ClassInfo/styles.ts
+++ b/src/entities/Class/ClassInfo/styles.ts
@@ -11,15 +11,9 @@ export const Container = styled.div`
   overflow: hidden;
   width: 100%;
 
-  @media (max-width: 1200px) {
-    flex-direction: column;
-    padding: 4rem 2rem;
-    gap: 2rem;
-  }
-
   @media (max-width: 768px) {
     padding: 2rem 1rem;
-}
+  }
 `;
 
 export const LeftSection = styled.div`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 1200px 구간의 반응형 처리를 제거하여 중간 해상도(약 768–1200px)에서 세로 배열과 추가 패딩/간격 변경이 더 이상 발생하지 않습니다.
  - 768px 이하의 반응형 동작은 그대로 유지되며 패딩은 2rem 1rem로 유지됩니다.
  - 레이아웃 일관성과 예측 가능성이 향상됩니다.
- 기타
  - 포맷 정리 및 개행 정돈(사용자 체감 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->