### PR TITLE
Fix(#215): 인자명 subject -> sort로 변경

### DIFF
--- a/src/features/Common/Class/TabSelector/category.ts
+++ b/src/features/Common/Class/TabSelector/category.ts
@@ -4,5 +4,5 @@ export const CATEGORY_FILTER_MAP: Record<CategoryKey, string | null> = {
   '전체': null,
   '일반교과': 'sort',
   '전공교과': 'professional',
-  '방과후교과': 'afterschool',
+  '방과후교과': 'afterSchool',
 };

--- a/src/pages/Student/MyClass/index.tsx
+++ b/src/pages/Student/MyClass/index.tsx
@@ -2,7 +2,7 @@ import * as s from './styles';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import TabSelector from '@/features/Common/Class/TabSelector';
-import { CategoryKey } from '@/features/Common/Class/TabSelector/category';
+import { CategoryKey, CATEGORY_FILTER_MAP } from '@/features/Common/Class/TabSelector/category';
 import { useMyClass } from '@/features/Common/MyClass/hooks/useMyClass';
 import { useModal } from '@/entities/UI/Modal/modal.hooks';
 import { Modal } from '@/entities/UI/Modal';
@@ -17,7 +17,8 @@ export default function MyClass() {
 
   // 탭 + 검색 필터링
   const filteredClasses = myClasses.filter((cls) => {
-    const tabMatch = selectedTab === '전체' ? true : cls.subject?.includes(selectedTab);
+    const filterValue = CATEGORY_FILTER_MAP[selectedTab as CategoryKey];
+    const tabMatch = filterValue === null ? true : cls.sort === filterValue;
     const searchMatch = cls.name.toLowerCase().includes(searchValue.toLowerCase());
     return tabMatch && searchMatch;
   });
@@ -61,7 +62,7 @@ export default function MyClass() {
               <s.CardDescription>{cls.description || '설명이 없습니다.'}</s.CardDescription>
               <s.InfoBlock>
                 <s.InfoContent>
-                  {cls.subject || '미정'} | {cls.assignedClass || '미정'}
+                  {cls.sort || '미정'} | {cls.assignedClass || '미정'}
                 </s.InfoContent>
               </s.InfoBlock>
             </s.Card>

--- a/src/pages/Teacher/MyClass/index.tsx
+++ b/src/pages/Teacher/MyClass/index.tsx
@@ -14,7 +14,7 @@ export default function MyClass() {
 
   const filteredClasses = myClasses.filter((cls) => {
     const filterValue = CATEGORY_FILTER_MAP[selectedTab as CategoryKey];
-    const tabMatch = filterValue === null ? true : cls.subject === filterValue;
+    const tabMatch = filterValue === null ? true : cls.sort === filterValue;
     const searchMatch = cls.name.toLowerCase().includes(searchValue.toLowerCase());
     return tabMatch && searchMatch;
   });
@@ -46,7 +46,7 @@ export default function MyClass() {
               <s.CardDescription>{cls.description || '설명이 없습니다.'}</s.CardDescription>
               <s.InfoBlock>
                 <s.InfoContent>
-                  {cls.subject || '미정'} | {cls.assignedClass || '미정'}
+                  {cls.sort || '미정'} | {cls.assignedClass || '미정'}
                 </s.InfoContent>
               </s.InfoBlock>
               <s.ButtonGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 없음
- 버그 수정
  - ‘방과후교과’ 카테고리 필터 매핑 수정(afterschool → afterSchool)으로 탭 필터 정확도 개선.
  - 학생/교사 마이클래스에서 카테고리 탭 선택 시 매핑된 필터 값으로 정확히 비교하며, 매핑값이 없음(null)일 때는 모두 표시.
- 리팩터링
  - 학생/교사 마이클래스 카드 정보에서 표기 값을 subject 대신 sort로 일원화하고, 값이 없을 경우 ‘미정’으로 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->