### PR TITLE
Refactor(#222): 선생님 이름 제대로 받아오도록 수정

### DIFF
--- a/src/entities/Class/ClassInfo/index.tsx
+++ b/src/entities/Class/ClassInfo/index.tsx
@@ -12,7 +12,7 @@ export const ClassInfo: React.FC<Partial<ClassInfoProps>> = ({
   const { classId } = useParams<{ classId: string }>();
   const [classData, setClassData] = useState({
     name: name || '',
-    teacherName: teacherName ? teacherName.join(', ') : "선생",
+    teacherNames: teacherName ? teacherName : [],
     description: description || '',
     progress: progress || 0,
     maxProgress: maxProgress || 100,
@@ -38,7 +38,7 @@ export const ClassInfo: React.FC<Partial<ClassInfoProps>> = ({
         setClassData({
           name: response.name || "",
           description: response.description || "",
-          teacherName: response.teacherNames ? response.teacherNames.join(', ') : "",
+          teacherNames: response.teacherNames || [],
           progress: 0,
           maxProgress: 100,
         });
@@ -71,7 +71,7 @@ export const ClassInfo: React.FC<Partial<ClassInfoProps>> = ({
 
         <s.TeacherRow>
           <FaUserAlt />
-          <span>{classData.teacherName}님</span>
+          <span>{classData.teacherNames.join(', ')}님</span>
         </s.TeacherRow>
 
         <ProgressBar progress={classData.progress} maxProgress={classData.maxProgress} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 반 정보 화면에서 교사 정보를 다수 명 표시합니다. 여러 교사가 있을 경우 이름을 “, ”로 구분해 나열하고 “님”을 공통 표기합니다.
- 개선
  - 교사 정보가 없을 때 기본 문자열(“선생”)을 표시하지 않고 비워, 잘못된 정보 노출을 줄였습니다.
  - 로딩·렌더링 동작은 동일하며, 사용자는 반의 실제 교사 구성을 더 명확히 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->