### PR TITLE
Design(#247): 수업입장 카드 여백 변경

### DIFF
--- a/src/pages/Student/MyClass/styles.ts
+++ b/src/pages/Student/MyClass/styles.ts
@@ -55,8 +55,18 @@ export const EmptyMessage = styled.p`
 
 export const Grid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 16px;
+
+  @media (max-width: 1200px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  @media (max-width: 992px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 export const Card = styled.div`

--- a/src/pages/Teacher/MyClass/styles.ts
+++ b/src/pages/Teacher/MyClass/styles.ts
@@ -45,8 +45,18 @@ export const EmptyMessage = styled.p`
 
 export const Grid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 16px;
+
+  @media (max-width: 1200px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  @media (max-width: 992px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 export const Card = styled.div`
@@ -59,7 +69,7 @@ export const Card = styled.div`
   max-width: 50vh;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: start;
   height: 10em;
   &:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * 학생·교사 마이클래스 그리드를 기본 4열로 고정하고 반응형으로 1200px≤3열, 992px≤2열, 768px≤1열로 조정해 카드 배치의 일관성과 가독성을 개선했습니다. 모바일에서도 화면 낭비를 줄여 사용성을 향상했습니다.
  * 교사 마이클래스 카드 내부 정렬을 양끝 배치에서 시작 정렬로 변경해 요소 간 간격을 균일화하고 시각적 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->