### PR TITLE
Fix Quiz Battle API implementation issues

### DIFF
--- a/src/features/QuizBattle/components/CreateRoom.tsx
+++ b/src/features/QuizBattle/components/CreateRoom.tsx
@@ -51,7 +51,11 @@ const CreateRoom: React.FC<CreateRoomProps> = ({ token, onRoomCreated }) => {
 
     QuizBattleService.createRoom(formData, (response) => {
       setIsCreating(false);
-      if (response.status === 'success' && response.roomCode) {
+      // 새 명세서: type: 'ROOM_CREATED' 또는 status: 'success' 확인
+      if (
+        (response.type === 'ROOM_CREATED' || response.status === 'success') &&
+        response.roomCode
+      ) {
         console.log('Room created:', response);
         if (onRoomCreated) {
           onRoomCreated(response.roomCode, true); // roomCode, isHost

--- a/src/features/QuizBattle/components/QuizBattleRoom.tsx
+++ b/src/features/QuizBattle/components/QuizBattleRoom.tsx
@@ -146,17 +146,16 @@ const QuizBattleRoom: React.FC<QuizBattleRoomProps> = ({
   const handleSubmitAnswer = (answerIndex: number) => {
     if (!currentQuestion || answerResult !== null) return;
 
-    const timeSpent = questionStartTime
-      ? Math.floor((Date.now() - questionStartTime) / 1000)
-      : 0;
+    // 새 명세서: timeSpent는 밀리초(ms) 단위
+    const timeSpent = questionStartTime ? Date.now() - questionStartTime : 0;
 
     setSelectedAnswer(answerIndex);
 
     QuizBattleService.submitAnswer(roomCode, {
       questionNumber: currentQuestion.questionNumber,
       answerIndex: answerIndex,
-      submittedAt: new Date().toISOString(),
-      timeSpent: timeSpent,
+      submittedAt: Date.now(), // epoch ms
+      timeSpent: timeSpent, // 밀리초 (ms)
     });
   };
 

--- a/src/features/QuizBattle/services/QuizBattleService.ts
+++ b/src/features/QuizBattle/services/QuizBattleService.ts
@@ -136,7 +136,10 @@ class QuizBattleService {
       '/topic/quiz/rooms',
       (message: IMessage) => {
         const response: WebSocketResponse = JSON.parse(message.body);
-        if (onRoomCreated) onRoomCreated(response);
+        // 새 명세서 기준: type: 'ROOM_CREATED' 확인
+        if (response.type === 'ROOM_CREATED' || response.status === 'success') {
+          if (onRoomCreated) onRoomCreated(response);
+        }
       }
     );
 
@@ -165,7 +168,15 @@ class QuizBattleService {
       `/topic/quiz/${roomCode}/participants`,
       (message: IMessage) => {
         const response: WebSocketResponse = JSON.parse(message.body);
-        if (callbacks.onParticipantUpdate) callbacks.onParticipantUpdate(response);
+        // 새 명세서: type: 'PARTICIPANT_JOINED', participants 필드 사용
+        // 하위 호환성: allParticipants도 지원
+        if (callbacks.onParticipantUpdate) {
+          // participants를 allParticipants로 매핑 (하위 호환성)
+          if (response.participants && !response.allParticipants) {
+            response.allParticipants = response.participants;
+          }
+          callbacks.onParticipantUpdate(response);
+        }
       }
     );
 
@@ -175,19 +186,63 @@ class QuizBattleService {
       (message: IMessage) => {
         const response: WebSocketResponse<QuestionData> = JSON.parse(message.body);
 
-        // 메시지 타입에 따라 콜백 실행
-        if (response.data && 'questionNumber' in response.data) {
-          // 문제 메시지
-          if (callbacks.onQuestion) callbacks.onQuestion(response.data);
-        } else if (response.status === 'finished') {
-          // 퀴즈 종료 메시지
-          if (callbacks.onQuizFinished) callbacks.onQuizFinished(response);
-        } else if (response.status === 'cancelled') {
-          // 방 취소 메시지
-          if (callbacks.onRoomCancelled) callbacks.onRoomCancelled(response);
-        } else if (response.status === 'error') {
-          // 에러 메시지
-          if (callbacks.onError) callbacks.onError(response);
+        // 새 명세서: type 필드로 메시지 구분
+        switch (response.type) {
+          case 'QUIZ_STARTED':
+          case 'NEXT_QUESTION':
+            // 문제 메시지 - QuestionData 형식으로 변환
+            if (callbacks.onQuestion) {
+              const questionData: QuestionData = {
+                questionNumber: (response as any).questionNumber,
+                questionText: (response as any).questionText,
+                options: (response as any).options || [],
+                timeLimit: (response as any).timeLimit,
+                totalQuestions: (response as any).totalQuestions,
+                correctAnswer: (response as any).correctAnswer,
+                explanation: (response as any).explanation,
+                difficulty: (response as any).difficulty,
+              };
+              callbacks.onQuestion(questionData);
+            }
+            break;
+
+          case 'QUIZ_FINISHED':
+            // 퀴즈 종료 메시지
+            if (callbacks.onQuizFinished) {
+              // rankings를 finalRankings로 매핑 (하위 호환성)
+              if (response.rankings && !response.finalRankings) {
+                response.finalRankings = response.rankings;
+              }
+              callbacks.onQuizFinished(response);
+            }
+            break;
+
+          case 'ROOM_CANCELLED':
+            // 방 취소 메시지
+            if (callbacks.onRoomCancelled) callbacks.onRoomCancelled(response);
+            break;
+
+          case 'ERROR':
+            // 에러 메시지
+            if (callbacks.onError) callbacks.onError(response);
+            break;
+
+          default:
+            // 하위 호환성: 기존 status 기반 처리
+            if (response.data && 'questionNumber' in response.data) {
+              // 문제 메시지
+              if (callbacks.onQuestion) callbacks.onQuestion(response.data);
+            } else if (response.status === 'finished') {
+              // 퀴즈 종료 메시지
+              if (callbacks.onQuizFinished) callbacks.onQuizFinished(response);
+            } else if (response.status === 'cancelled') {
+              // 방 취소 메시지
+              if (callbacks.onRoomCancelled) callbacks.onRoomCancelled(response);
+            } else if (response.status === 'error') {
+              // 에러 메시지
+              if (callbacks.onError) callbacks.onError(response);
+            }
+            break;
         }
       }
     );
@@ -242,8 +297,8 @@ class QuizBattleService {
       body: JSON.stringify({
         questionNumber: answerData.questionNumber,
         answerIndex: answerData.answerIndex,
-        submittedAt: answerData.submittedAt || new Date().toISOString(),
-        timeSpent: answerData.timeSpent,
+        submittedAt: answerData.submittedAt || Date.now(), // epoch ms
+        timeSpent: answerData.timeSpent, // 밀리초 (ms) 단위
       }),
     });
   }

--- a/src/features/QuizBattle/types/index.ts
+++ b/src/features/QuizBattle/types/index.ts
@@ -1,9 +1,23 @@
+// 메시지 타입 정의 (백엔드 명세서 기준)
+export type MessageType =
+  | 'ROOM_CREATED'
+  | 'PARTICIPANT_JOINED'
+  | 'QUIZ_STARTED'
+  | 'ANSWER_RESULT'
+  | 'NEXT_QUESTION'
+  | 'QUIZ_FINISHED'
+  | 'RANKINGS_UPDATED'
+  | 'ROOM_CANCELLED'
+  | 'ERROR';
+
 export interface ParticipantInfo {
   username: string;
   userId: string;
-  isHost: boolean;
+  isHost?: boolean;
   score: number;
+  correctAnswers: number;
   isReady?: boolean;
+  joinedAt?: number; // epoch ms
 }
 
 export interface QuestionData {
@@ -12,30 +26,36 @@ export interface QuestionData {
   options: string[];
   timeLimit: number;
   totalQuestions: number;
+  correctAnswer?: number; // 0-based index (답안 제출 후 받을 수 있음)
+  explanation?: string; // 해설
+  difficulty?: string; // Easy, Medium, Hard
 }
 
 export interface AnswerSubmission {
   questionNumber: number;
   answerIndex: number;
-  submittedAt: string;
-  timeSpent: number;
+  submittedAt: number; // epoch ms로 변경
+  timeSpent: number; // 밀리초 (ms) 단위
 }
 
 export interface AnswerResult {
+  type: 'ANSWER_RESULT';
+  questionNumber: number;
   isCorrect: boolean;
   points: number;
-  answerIndex: number;
-  correctAnswerIndex?: number;
-  message?: string;
+  correctAnswer: number; // 정답 인덱스
+  explanation?: string; // 해설
 }
 
 export interface RankingData {
+  rank?: number;
   username: string;
   userId: string;
   totalScore: number;
   correctAnswers: number;
   totalQuestions: number;
-  rank?: number;
+  accuracy?: number; // 정답률 (%)
+  averageResponseTime?: number; // 평균 응답 시간 (ms)
 }
 
 export interface RoomData {
@@ -55,23 +75,106 @@ export interface RoomInfo extends RoomData {
   createdAt: string;
 }
 
+// 방 생성 응답
+export interface RoomCreatedMessage {
+  type: 'ROOM_CREATED';
+  roomCode: string;
+  hostName: string;
+  maxParticipants: number;
+  questionCount: number;
+  timePerQuestion: number;
+  createdAt: string;
+}
+
+// 참가자 입장/퇴장 메시지
+export interface ParticipantUpdateMessage {
+  type: 'PARTICIPANT_JOINED';
+  roomCode: string;
+  participants: ParticipantInfo[];
+  currentParticipantCount: number;
+}
+
+// 퀴즈 시작 메시지
+export interface QuizStartedMessage {
+  type: 'QUIZ_STARTED';
+  questionNumber: number;
+  questionText: string;
+  options: string[];
+  timeLimit: number;
+  totalQuestions: number;
+}
+
+// 다음 문제 메시지
+export interface NextQuestionMessage {
+  type: 'NEXT_QUESTION';
+  questionNumber: number;
+  questionText: string;
+  options: string[];
+  timeLimit: number;
+  totalQuestions: number;
+}
+
+// 퀴즈 종료 메시지
+export interface QuizFinishedMessage {
+  type: 'QUIZ_FINISHED';
+  message: string;
+  rankings: RankingData[];
+}
+
+// 순위 업데이트 메시지
+export interface RankingsUpdatedMessage {
+  type: 'RANKINGS_UPDATED';
+  rankings: RankingData[];
+  updatedAt: number;
+}
+
+// 방 취소 메시지
+export interface RoomCancelledMessage {
+  type: 'ROOM_CANCELLED';
+  message: string;
+  reason: string;
+}
+
+// 에러 메시지
+export interface ErrorMessage {
+  type: 'ERROR';
+  message: string;
+  code?: string;
+}
+
+// 통합 WebSocket 메시지 타입
+export type WebSocketMessage =
+  | RoomCreatedMessage
+  | ParticipantUpdateMessage
+  | QuizStartedMessage
+  | NextQuestionMessage
+  | QuizFinishedMessage
+  | RankingsUpdatedMessage
+  | RoomCancelledMessage
+  | AnswerResult
+  | ErrorMessage;
+
+// 하위 호환성을 위한 기존 인터페이스 (deprecated)
 export interface WebSocketResponse<T = any> {
-  status: 'success' | 'error' | 'playing' | 'finished' | 'cancelled';
+  status?: 'success' | 'error' | 'playing' | 'finished' | 'cancelled';
+  type?: MessageType;
   message?: string;
   roomCode?: string;
   data?: T;
   allParticipants?: ParticipantInfo[];
+  participants?: ParticipantInfo[];
   finalRankings?: RankingData[];
   rankings?: RankingData[];
+  currentParticipantCount?: number;
 }
 
 export interface QuizBattleCallbacks {
-  onParticipantUpdate?: (response: WebSocketResponse) => void;
+  onParticipantUpdate?: (response: ParticipantUpdateMessage | WebSocketResponse) => void;
   onQuestion?: (question: QuestionData) => void;
   onAnswerResult?: (result: AnswerResult) => void;
-  onQuizFinished?: (response: WebSocketResponse) => void;
-  onRoomCancelled?: (response: WebSocketResponse) => void;
-  onError?: (error: any) => void;
+  onQuizFinished?: (response: QuizFinishedMessage | WebSocketResponse) => void;
+  onRoomCancelled?: (response: RoomCancelledMessage | WebSocketResponse) => void;
+  onError?: (error: ErrorMessage | any) => void;
 }
 
 export type GameStatus = 'waiting' | 'playing' | 'finished';


### PR DESCRIPTION
백엔드 API 명세서 v1.0 기준으로 Quiz Battle 관련 코드 수정:

## 주요 변경사항

### 1. 타입 정의 개선 (types/index.ts)
- 메시지 타입 Enum 추가 (ROOM_CREATED, PARTICIPANT_JOINED, QUIZ_STARTED 등)
- 명세서 기준으로 새로운 메시지 인터페이스 추가:
  * RoomCreatedMessage
  * ParticipantUpdateMessage
  * QuizStartedMessage/NextQuestionMessage
  * QuizFinishedMessage
  * RankingsUpdatedMessage
  * RoomCancelledMessage
  * ErrorMessage
- QuestionData에 explanation, difficulty 필드 추가
- RankingData에 rank, accuracy, averageResponseTime 필드 추가
- ParticipantInfo에 correctAnswers, joinedAt 필드 추가
- AnswerSubmission: submittedAt을 string에서 number(epoch ms)로 변경
- AnswerResult에 type, questionNumber, correctAnswer, explanation 추가

### 2. QuizBattleService 수정
- 방 생성 응답 처리: type: 'ROOM_CREATED' 확인 추가
- 참가자 업데이트: participants 필드를 allParticipants로 매핑 (하위 호환성)
- 게임 이벤트: type 필드 기반 switch-case로 메시지 구분
  * QUIZ_STARTED/NEXT_QUESTION → QuestionData 변환
  * QUIZ_FINISHED → rankings를 finalRankings로 매핑
  * ROOM_CANCELLED, ERROR 처리
- 답안 제출: submittedAt을 epoch ms로, timeSpent를 밀리초 단위로 변경

### 3. 컴포넌트 수정
- QuizBattleRoom: 답안 제출 시 timeSpent를 밀리초로 계산
- CreateRoom: 방 생성 응답 처리 시 type 확인 추가

## 명세서 준수 사항
- ✅ 시간 단위: timeSpent, submittedAt 모두 밀리초(ms) 사용
- ✅ 메시지 타입: type 필드로 명확히 구분
- ✅ 하위 호환성: 기존 status 기반 처리도 유지
- ✅ 필드 매핑: participants ↔ allParticipants, rankings ↔ finalRankings