### PR TITLE
Fix(#531): 과제 수정 시 파일 업로드 API FormData 키 수정

### DIFF
--- a/src/features/Common/Class/api/useAssignment.ts
+++ b/src/features/Common/Class/api/useAssignment.ts
@@ -92,8 +92,12 @@ export const AssignmentsApi = {
   fileUpload: async (assignmentId: string | number, files: File[]): Promise<unknown> => {
     try {
       const formData = new FormData();
-      files.forEach((f) => formData.append('file', f));
-      const res = await Customapi.post(`${API_BASE_URL}/${assignmentId}/file`, formData);
+      files.forEach((f) => formData.append('files', f));
+      const res = await Customapi.post(`${API_BASE_URL}/${assignmentId}/file`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
       if (res.status < 200 || res.status >= 300) {
         console.error(`파일 업로드 실패: status ${res.status}`);
         return null;


### PR DESCRIPTION
# [#531] 과제 수정 시 파일 업로드 API 수정

   ---

   ## 📑 개요
   과제 수정 페이지에서 파일 추가 기능이 작동하지 않는 문제를 수정했습니다. FormData의 키 이름과 헤더 설정이 백엔드 API 스펙과 맞지 않아 발생한 문제였습니다.

   ---

   ## ✅ 작업 내용
   - [x] FormData 키를 'file'에서 'files'로 변경하여 백엔드 API 스펙과 일치시킴
   - [x] multipart/form-data 헤더를 명시적으로 설정하여 백엔드에서 multipart request로 인식되도록 수정
   - [x] 프로젝트 내 다른 파일 업로드 API들과 동일한 형식으로 통일

   ---

   ## 🔗 관련 이슈
   Close #531

   ---

   ## 📌 체크리스트
   - [x] 코드 컨벤션을 지켰나요?
   - [x] 커밋 메시지 컨벤션을 지켰나요?
   - [x] 테스트를 완료했나요?