### PR TITLE
Rqf 6 퀴즈 기능 오류 수정

### DIFF
--- a/src/features/QuizBattle/components/QuizBattleRoom.tsx
+++ b/src/features/QuizBattle/components/QuizBattleRoom.tsx
@@ -6,6 +6,7 @@ import type {
   GameStatus,
   RankingData,
   AnswerResult,
+  AnswerRevealMessage,
 } from '../types';
 import {
   RoomContainer,
@@ -49,6 +50,7 @@ const QuizBattleRoom: React.FC<QuizBattleRoomProps> = ({
   const [timeLeft, setTimeLeft] = useState(0);
   const [questionStartTime, setQuestionStartTime] = useState<number | null>(null);
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
+  const [revealedAnswer, setRevealedAnswer] = useState<AnswerRevealMessage | null>(null);
 
   useEffect(() => {
     // WebSocket 연결 (token은 QuizBattleService가 자동으로 localStorage에서 가져옴)
@@ -116,12 +118,19 @@ const QuizBattleRoom: React.FC<QuizBattleRoomProps> = ({
         setGameStatus('playing');
         setAnswerResult(null);
         setSelectedAnswer(null);
+        setRevealedAnswer(null); // 새 문제 시작 시 이전 정답 공개 초기화
       },
 
       // 답변 결과
       onAnswerResult: (result) => {
         console.log('Answer result:', result);
         setAnswerResult(result);
+      },
+
+      // 정답 공개 (시간 종료 시)
+      onAnswerReveal: (reveal) => {
+        console.log('Answer revealed:', reveal);
+        setRevealedAnswer(reveal);
       },
 
       // 퀴즈 종료
@@ -271,7 +280,7 @@ const QuizBattleRoom: React.FC<QuizBattleRoomProps> = ({
               <OptionButton
                 key={idx}
                 onClick={() => handleSubmitAnswer(idx)}
-                disabled={answerResult !== null}
+                disabled={answerResult !== null || timeLeft === 0}
                 selected={selectedAnswer === idx}
                 correct={
                   answerResult !== null &&
@@ -289,11 +298,27 @@ const QuizBattleRoom: React.FC<QuizBattleRoomProps> = ({
             ))}
           </OptionsGrid>
 
+          {/* 답변 결과 표시 */}
           {answerResult && (
             <ResultMessage correct={answerResult.isCorrect}>
               {answerResult.isCorrect ? '✓ 정답입니다!' : '✗ 틀렸습니다!'}
               <br />
               획득 점수: {answerResult.points}점
+            </ResultMessage>
+          )}
+
+          {/* 정답 공개 메시지 (백엔드에서 시간 종료 시 자동 전송) */}
+          {revealedAnswer && (
+            <ResultMessage correct={false}>
+              ⏰ 시간이 종료되었습니다!
+              <br />
+              정답: {currentQuestion?.options[revealedAnswer.correctAnswer]}
+              {revealedAnswer.explanation && (
+                <>
+                  <br />
+                  해설: {revealedAnswer.explanation}
+                </>
+              )}
             </ResultMessage>
           )}
 

--- a/src/features/QuizBattle/components/QuizBattleRoom.tsx
+++ b/src/features/QuizBattle/components/QuizBattleRoom.tsx
@@ -152,8 +152,33 @@ const QuizBattleRoom: React.FC<QuizBattleRoomProps> = ({
       // 방 취소
       onRoomCancelled: (response) => {
         console.log('Room cancelled:', response);
-        alert('방이 호스트에 의해 취소되었습니다.');
-        if (onLeaveRoom) onLeaveRoom();
+
+        // reason에 따른 메시지 표시
+        let message = '퀴즈방이 종료되었습니다.';
+        if ('reason' in response) {
+          switch (response.reason) {
+            case 'host_disconnected':
+              message = '호스트의 연결이 끊겨 퀴즈방이 종료되었습니다.';
+              break;
+            case 'host_left':
+              message = '호스트가 퀴즈방을 나가 방이 종료되었습니다.';
+              break;
+            case 'cancelled_by_host':
+              message = '호스트가 퀴즈방을 취소했습니다.';
+              break;
+          }
+        }
+
+        // WebSocket 연결 종료
+        QuizBattleService.leaveRoom(roomCode);
+        QuizBattleService.disconnect();
+
+        // 알림 표시 후 메인 페이지로 이동
+        alert(message);
+
+        if (onLeaveRoom) {
+          onLeaveRoom();
+        }
       },
 
       // 에러

--- a/src/features/QuizBattle/services/QuizBattleService.ts
+++ b/src/features/QuizBattle/services/QuizBattleService.ts
@@ -185,6 +185,7 @@ class QuizBattleService {
       `/topic/quiz/${roomCode}/game`,
       (message: IMessage) => {
         const response: WebSocketResponse<QuestionData> = JSON.parse(message.body);
+        console.log('[QuizBattle] Game event received:', response);
 
         // 새 명세서: type 필드로 메시지 구분
         switch (response.type) {
@@ -226,7 +227,12 @@ class QuizBattleService {
 
           case 'ROOM_CANCELLED':
             // 방 취소 메시지
-            if (callbacks.onRoomCancelled) callbacks.onRoomCancelled(response);
+            console.log('[QuizBattle] ROOM_CANCELLED detected!', response);
+            if (callbacks.onRoomCancelled) {
+              callbacks.onRoomCancelled(response);
+            } else {
+              console.warn('[QuizBattle] onRoomCancelled callback is not defined!');
+            }
             break;
 
           case 'ERROR':
@@ -236,6 +242,7 @@ class QuizBattleService {
 
           default:
             // 하위 호환성: 기존 status 기반 처리
+            console.log('[QuizBattle] Processing message in default case, type:', response.type, 'status:', response.status);
             if (response.status === 'success' && (response as any).correctAnswer !== undefined) {
               // 정답 공개 메시지 (status 기반)
               if (callbacks.onAnswerReveal) callbacks.onAnswerReveal(response as any);
@@ -247,7 +254,12 @@ class QuizBattleService {
               if (callbacks.onQuizFinished) callbacks.onQuizFinished(response);
             } else if (response.status === 'cancelled') {
               // 방 취소 메시지
-              if (callbacks.onRoomCancelled) callbacks.onRoomCancelled(response);
+              console.log('[QuizBattle] status=cancelled detected!', response);
+              if (callbacks.onRoomCancelled) {
+                callbacks.onRoomCancelled(response);
+              } else {
+                console.warn('[QuizBattle] onRoomCancelled callback is not defined!');
+              }
             } else if (response.status === 'error') {
               // 에러 메시지
               if (callbacks.onError) callbacks.onError(response);

--- a/src/features/QuizBattle/services/QuizBattleService.ts
+++ b/src/features/QuizBattle/services/QuizBattleService.ts
@@ -206,6 +206,13 @@ class QuizBattleService {
             }
             break;
 
+          case 'ANSWER_REVEAL':
+            // 정답 공개 메시지 (시간 종료 시)
+            if (callbacks.onAnswerReveal) {
+              callbacks.onAnswerReveal(response as any);
+            }
+            break;
+
           case 'QUIZ_FINISHED':
             // 퀴즈 종료 메시지
             if (callbacks.onQuizFinished) {
@@ -229,7 +236,10 @@ class QuizBattleService {
 
           default:
             // 하위 호환성: 기존 status 기반 처리
-            if (response.data && 'questionNumber' in response.data) {
+            if (response.status === 'success' && (response as any).correctAnswer !== undefined) {
+              // 정답 공개 메시지 (status 기반)
+              if (callbacks.onAnswerReveal) callbacks.onAnswerReveal(response as any);
+            } else if (response.data && 'questionNumber' in response.data) {
               // 문제 메시지
               if (callbacks.onQuestion) callbacks.onQuestion(response.data);
             } else if (response.status === 'finished') {

--- a/src/features/QuizBattle/types/index.ts
+++ b/src/features/QuizBattle/types/index.ts
@@ -4,6 +4,7 @@ export type MessageType =
   | 'PARTICIPANT_JOINED'
   | 'QUIZ_STARTED'
   | 'ANSWER_RESULT'
+  | 'ANSWER_REVEAL'
   | 'NEXT_QUESTION'
   | 'QUIZ_FINISHED'
   | 'RANKINGS_UPDATED'
@@ -45,6 +46,18 @@ export interface AnswerResult {
   points: number;
   correctAnswer: number; // 정답 인덱스
   explanation?: string; // 해설
+}
+
+// 정답 공개 메시지 (시간 종료 시)
+export interface AnswerRevealMessage {
+  type?: 'ANSWER_REVEAL';
+  status?: string;
+  questionNumber: number;
+  correctAnswer: number; // 정답 인덱스
+  explanation?: string; // 해설
+  statistics?: Map<number, number>; // 각 선택지별 응답 수
+  totalAnswers?: number; // 전체 응답 수
+  message?: string;
 }
 
 export interface RankingData {
@@ -152,6 +165,7 @@ export type WebSocketMessage =
   | RankingsUpdatedMessage
   | RoomCancelledMessage
   | AnswerResult
+  | AnswerRevealMessage
   | ErrorMessage;
 
 // 하위 호환성을 위한 기존 인터페이스 (deprecated)
@@ -172,6 +186,7 @@ export interface QuizBattleCallbacks {
   onParticipantUpdate?: (response: ParticipantUpdateMessage | WebSocketResponse) => void;
   onQuestion?: (question: QuestionData) => void;
   onAnswerResult?: (result: AnswerResult) => void;
+  onAnswerReveal?: (reveal: AnswerRevealMessage) => void;
   onQuizFinished?: (response: QuizFinishedMessage | WebSocketResponse) => void;
   onRoomCancelled?: (response: RoomCancelledMessage | WebSocketResponse) => void;
   onError?: (error: ErrorMessage | any) => void;

--- a/src/features/QuizBattle/types/index.ts
+++ b/src/features/QuizBattle/types/index.ts
@@ -144,8 +144,10 @@ export interface RankingsUpdatedMessage {
 // 방 취소 메시지
 export interface RoomCancelledMessage {
   type: 'ROOM_CANCELLED';
+  roomCode: string;
   message: string;
-  reason: string;
+  reason: 'host_disconnected' | 'host_left' | 'cancelled_by_host';
+  status?: 'cancelled'; // 하위 호환성
 }
 
 // 에러 메시지

--- a/src/pages/Student/Quiz/index.tsx
+++ b/src/pages/Student/Quiz/index.tsx
@@ -145,6 +145,45 @@ export default function STUQuiz() {
                         setMyRanking(myRank || null);
                         setStep("finish");
                     }
+                    // 방 취소
+                    else if (msg.status === "cancelled") {
+                        console.log("[STU Quiz] 🚫 방이 취소되었습니다:", msg);
+
+                        // reason에 따른 메시지 표시
+                        const msgWithReason = msg as { reason?: string; message?: string };
+                        let alertMessage = '퀴즈방이 종료되었습니다.';
+
+                        if (msgWithReason.reason) {
+                            switch (msgWithReason.reason) {
+                                case 'host_disconnected':
+                                    alertMessage = '호스트의 연결이 끊겨 퀴즈방이 종료되었습니다.';
+                                    break;
+                                case 'host_left':
+                                    alertMessage = '호스트가 퀴즈방을 나가 방이 종료되었습니다.';
+                                    break;
+                                case 'cancelled_by_host':
+                                    alertMessage = '호스트가 퀴즈방을 취소했습니다.';
+                                    break;
+                                default:
+                                    alertMessage = msgWithReason.message || '퀴즈방이 종료되었습니다.';
+                            }
+                        } else if (msgWithReason.message) {
+                            alertMessage = msgWithReason.message;
+                        }
+
+                        alert(alertMessage);
+
+                        // 초기 상태로 돌아가기
+                        setStep("joinQuiz");
+                        setRoomCode("");
+                        setCharacter(null);
+                        setParticipants([]);
+                        setCurrentQuestion(null);
+                        setSelectedAnswer(null);
+                        setAnswerResult(null);
+                        setAnswerReveal(null);
+                        setMyRanking(null);
+                    }
                 }
             ),
             // 개인 답변 결과 구독

--- a/src/pages/Teacher/Quiz/index.tsx
+++ b/src/pages/Teacher/Quiz/index.tsx
@@ -160,6 +160,42 @@ export default function TCHQuiz() {
                         setFinalRanking(msg.finalRankings ?? []);
                         setStep("finish");
                     }
+                    // 방 취소
+                    else if (msg.status === "cancelled") {
+                        console.log("[TCH Quiz] 🚫 방이 취소되었습니다:", msg);
+
+                        const msgWithReason = msg as { reason?: string; message?: string };
+                        let alertMessage = '퀴즈방이 종료되었습니다.';
+
+                        if (msgWithReason.reason) {
+                            switch (msgWithReason.reason) {
+                                case 'host_disconnected':
+                                    alertMessage = '호스트의 연결이 끊겨 퀴즈방이 종료되었습니다.';
+                                    break;
+                                case 'host_left':
+                                    alertMessage = '호스트가 퀴즈방을 나가 방이 종료되었습니다.';
+                                    break;
+                                case 'cancelled_by_host':
+                                    alertMessage = '호스트가 퀴즈방을 취소했습니다.';
+                                    break;
+                                default:
+                                    alertMessage = msgWithReason.message || '퀴즈방이 종료되었습니다.';
+                            }
+                        } else if (msgWithReason.message) {
+                            alertMessage = msgWithReason.message;
+                        }
+
+                        alert(alertMessage);
+
+                        // 초기 상태로 돌아가기
+                        setStep("create");
+                        setRoomCode("");
+                        setParticipants([]);
+                        setCurrentQuestion(null);
+                        setCurrentRanking([]);
+                        setFinalRanking([]);
+                        setAnswerReveal(null);
+                    }
                 }
             ),
             // 랭킹 업데이트


### PR DESCRIPTION
# [RQF-6] 퀴즈 기능 오류 수정

  ---

  ## 📑 개요
  퀴즈 배틀 기능에서 발생하는 주요 오류들을 수정했습니다. 호스트 연결 해제 시 학생들의 연결도 정상적으로 종료되도록 하고, 시간 종료 시 정답 확인 기능을 개선했습니다.

  ---

  ## ✅ 작업 내용
  - [x] 호스트 연결 끊김 시 학생들 연결 정상 종료 처리
    - `ROOM_CANCELLED` 이벤트 타입 추가 및 처리
    - 방 취소 사유별 메시지 구분 (`host_disconnected`, `host_left`, `cancelled_by_host`)
    - WebSocket 연결 정상 종료 및 초기 상태 복원
  - [x] 시간 종료 시 정답 확인 기능 개선
    - `ANSWER_REVEAL` 이벤트 타입 추가
    - 시간 종료 시 정답 및 해설 자동 표시
    - 시간 종료 후 답변 제출 비활성화
  - [x] QuizBattleService에서 새로운 메시지 타입 처리 로직 추가
  - [x] Teacher/Student 페이지에서 방 취소 이벤트 처리 추가
  - [x] 타입 정의 개선 (`AnswerRevealMessage`, `RoomCancelledMessage`)

  ---

  ## 📌 체크리스트
  - [ ] 코드 컨벤션을 지켰나요?
  - [ ] 커밋 메시지 컨벤션을 지켰나요?
  - [ ] 테스트를 완료했나요?

[RQF-6]: https://haeyul.atlassian.net/browse/RQF-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ