### PR TITLE
fix: #607 메모리 누수 정리

### DIFF
--- a/src/app/hooks/useAccessToken.ts
+++ b/src/app/hooks/useAccessToken.ts
@@ -19,6 +19,7 @@ export const useAuth = (): AuthHook => {
   const [user, setUser] = useRecoilState(userState);
   const [loading, setLoading] = useState(true); // 로딩 상태 추가
   const justLoggedInRef = useRef(false);
+  const loginGraceTimerRef = useRef<number | null>(null);
 
   // 로그인 시 토큰 저장
   const setAuthInfo = useCallback((accessToken: string) => {
@@ -27,7 +28,10 @@ export const useAuth = (): AuthHook => {
     // mark that we just logged in to avoid immediate logout race
     justLoggedInRef.current = true;
     // give it a short grace period for other effects to settle
-    setTimeout(() => {
+    if (loginGraceTimerRef.current) {
+      window.clearTimeout(loginGraceTimerRef.current);
+    }
+    loginGraceTimerRef.current = window.setTimeout(() => {
       justLoggedInRef.current = false;
     }, 1500);
   }, []);
@@ -180,6 +184,14 @@ export const useAuth = (): AuthHook => {
 
     fetchUserInfo();
   }, [accessToken, setUser, removeAuthInfo]);
+
+  useEffect(() => {
+    return () => {
+      if (loginGraceTimerRef.current) {
+        window.clearTimeout(loginGraceTimerRef.current);
+      }
+    };
+  }, []);
 
   return { accessToken, user, setAuthInfo, removeAuthInfo, loading };
 };


### PR DESCRIPTION
## 변경 내용
- `useAccessToken`의 로그인 유예 타이머 ID 저장
- 재설정/언마운트 시 `clearTimeout` 정리

## 관련 이슈
- closes #607