### PR TITLE
fix(#618): cleanup login navigation timeout on effect cleanup

### DIFF
--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,6 @@
 import LoginButton from "@/entities/Login/LoginButton"
 import * as S from './styles'
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import Image from '@/assets/images/registerImg.webp';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from "@/app/hooks/useAccessToken";
@@ -8,47 +8,43 @@ import { useAuth } from "@/app/hooks/useAccessToken";
 export function Login() {
     const { setAuthInfo, user, loading } = useAuth();
     const navigate = useNavigate();
-    const navigateTimeoutRef = useRef<number | null>(null);
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
         const urlToken = params.get('access_token');
 
-        if (urlToken) {
-            // Case 1: Token is in the URL (coming from OAuth).
-            console.log("로그인 페이지: URL에서 Access Token을 발견했습니다. 인증 정보를 설정합니다. 사용자 정보 로딩 완료 시 메인으로 이동합니다.");
-            setAuthInfo(urlToken);
-            // Wait for user info to be loaded in useAuth, but add a safety timeout
-            const start = Date.now();
-            const checkAndNav = () => {
-                // if user data is present or loading finished, navigate
-                if ((user && user.userId) || !loading) {
-                    navigate('/', { replace: true });
-                    return;
-                }
-                // safety: timeout after 3s
-                if (Date.now() - start > 3000) {
-                    navigate('/', { replace: true });
-                    return;
-                }
-                // otherwise recheck shortly
-                navigateTimeoutRef.current = window.setTimeout(checkAndNav, 200) as unknown as number;
-            };
-            checkAndNav();
-        } else {
-            // Case 2: No token in URL. Stay on login page.
+        if (!urlToken) {
             console.log("로그인 페이지: 인증 토큰이 없습니다. 로그인 페이지에 머무릅니다.");
+            return;
         }
-    }, [setAuthInfo, navigate, user, loading]);
 
-    useEffect(() => {
+        console.log("로그인 페이지: URL에서 Access Token을 발견했습니다. 인증 정보를 설정합니다. 사용자 정보 로딩 완료 시 메인으로 이동합니다.");
+        setAuthInfo(urlToken);
+
+        const start = Date.now();
+        let timeoutId: number | null = null;
+
+        const checkAndNav = () => {
+            if ((user && user.userId) || !loading) {
+                navigate('/', { replace: true });
+                return;
+            }
+            if (Date.now() - start > 3000) {
+                navigate('/', { replace: true });
+                return;
+            }
+            timeoutId = window.setTimeout(checkAndNav, 200) as unknown as number;
+        };
+        checkAndNav();
+
         return () => {
-            if (navigateTimeoutRef.current) {
-                clearTimeout(navigateTimeoutRef.current);
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
             }
         };
-    }, []);
-    
+    }, [setAuthInfo, navigate, user, loading]);
+
+
     return (
         <S.Container>
             <S.Left>


### PR DESCRIPTION
useEffect가 user/loading 의존성 변경으로 재실행될 때 이전 setTimeout이 정리되지 않아 타이머가 누적되고 navigate가 중복 호출되던 문제를 수정합니다. 별도 cleanup effect 대신 메인 effect 내부에 클로저 변수로 timeoutId를 관리하도록 변경했습니다.